### PR TITLE
Add OpenRouter free tier support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Get your OpenAI API key from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=your_openai_api_key_here
 
+# Get your FREE OpenRouter API key from: https://openrouter.ai/keys (No credit card!)
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+
 # Optional: Default model to use
 # Options: 'auto' (Claude picks best model), 'pro', 'flash', 'o3', 'o3-mini'
 # When set to 'auto', Claude will select the best model for each task

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The final implementation resulted in a 26% improvement in JSON parsing performan
 ### 1. Get API Keys (at least one required)
 - **Gemini**: Visit [Google AI Studio](https://makersuite.google.com/app/apikey) and generate an API key. For best results with Gemini 2.5 Pro, use a paid API key as the free tier has limited access to the latest models.
 - **OpenAI**: Visit [OpenAI Platform](https://platform.openai.com/api-keys) to get an API key for O3 model access.
+- **OpenRouter (FREE!)**: Visit [OpenRouter](https://openrouter.ai/keys) to get a FREE API key - no credit card required! Enables access to 15+ powerful models at zero cost.
 
 ### 2. Clone and Set Up
 
@@ -128,9 +129,10 @@ nano .env
 # The file will contain:
 # GEMINI_API_KEY=your-gemini-api-key-here  # For Gemini models
 # OPENAI_API_KEY=your-openai-api-key-here  # For O3 model
+# OPENROUTER_API_KEY=your-key-here  # For FREE models!
 # WORKSPACE_ROOT=/Users/your-username  (automatically configured)
 
-# Note: At least one API key is required (Gemini or OpenAI)
+# Note: At least one API key is required (Gemini, OpenAI, or OpenRouter)
 ```
 
 ### 4. Configure Claude
@@ -727,6 +729,7 @@ DEFAULT_MODEL=auto  # Claude picks the best model automatically
 # API Keys (at least one required)
 GEMINI_API_KEY=your-gemini-key    # Enables Gemini Pro & Flash
 OPENAI_API_KEY=your-openai-key    # Enables O3, O3-mini
+OPENROUTER_API_KEY=your-key       # Enables FREE models! (No credit card)
 ```
 
 **How Auto Mode Works:**
@@ -742,6 +745,12 @@ OPENAI_API_KEY=your-openai-key    # Enables O3, O3-mini
 | **`flash`** (Gemini 2.0 Flash) | Google | 1M tokens | Ultra-fast responses | Quick checks, formatting, simple analysis |
 | **`o3`** | OpenAI | 200K tokens | Strong logical reasoning | Debugging logic errors, systematic analysis |
 | **`o3-mini`** | OpenAI | 200K tokens | Balanced speed/quality | Moderate complexity tasks |
+| **FREE MODELS via OpenRouter** | | | | |
+| **`qwen-coder-free`** | OpenRouter | 128K tokens | FREE: Best overall balance (32B) | General chat + code tasks |
+| **`deepseek-r1-free`** | OpenRouter | 163K tokens | FREE: Advanced reasoning (671B!) | Complex logical problems |
+| **`mistral-devstral-free`** | OpenRouter | 128K tokens | FREE: Code specialist | Code review and generation |
+| **`gemini-flash-free`** | OpenRouter | 1M tokens | FREE: Ultra-fast analysis | Quick checks and formatting |
+| **`llama-70b-free`** | OpenRouter | 128K tokens | FREE: High-quality chat (70B) | Thoughtful conversations |
 
 **Manual Model Selection:**
 You can specify a default model instead of auto mode:
@@ -763,6 +772,25 @@ Regardless of your default setting, you can specify models per request:
 **Model Capabilities:**
 - **Gemini Models**: Support thinking modes (minimal to max), web search, 1M context
 - **O3 Models**: Excellent reasoning, systematic analysis, 200K context
+- **Free OpenRouter Models**: Powerful models at zero cost, various specializations
+
+### Free Models via OpenRouter
+
+Access powerful AI models completely FREE with an OpenRouter API key:
+
+**Getting Started:**
+1. Get your FREE API key at https://openrouter.ai/keys (no credit card!)
+2. Add to your .env: `OPENROUTER_API_KEY=your-key-here`
+3. Use models with `-free` suffix: "Use qwen-coder-free for code review"
+
+**Available Free Models:**
+- **DeepSeek R1** (`deepseek-r1-free`) - 671B params, advanced reasoning
+- **Qwen 2.5 Coder** (`qwen-coder-free`) - Best overall balance for code
+- **Mistral Devstral** (`mistral-devstral-free`) - Code specialist
+- **Gemini Flash Free** (`gemini-flash-free`) - 1M context, ultra-fast
+- **Llama 3.3 70B** (`llama-70b-free`) - High-quality conversations
+
+**Rate Limits:** Free tier has daily limits (50-1000 requests depending on model)
 
 ### Temperature Defaults
 Different tools use optimized temperature settings:

--- a/config.py
+++ b/config.py
@@ -34,6 +34,14 @@ VALID_MODELS = [
     "o3-mini",
     "gemini-2.5-flash-preview-05-20",
     "gemini-2.5-pro-preview-06-05",
+    # Free OpenRouter models
+    "qwen-coder-free",
+    "deepseek-r1-free",
+    "mistral-devstral-free",
+    "gemini-flash-free",
+    "llama-70b-free",
+    "qwq-32b-free",
+    "nemotron-free",
 ]
 if DEFAULT_MODEL not in VALID_MODELS:
     import logging
@@ -57,6 +65,14 @@ MODEL_CAPABILITIES_DESC = {
     # Full model names also supported
     "gemini-2.5-flash-preview-05-20": "Ultra-fast (1M context) - Quick analysis, simple queries, rapid iterations",
     "gemini-2.5-pro-preview-06-05": "Deep reasoning + thinking mode (1M context) - Complex problems, architecture, deep analysis",
+    # Free OpenRouter models
+    "qwen-coder-free": "FREE: Best overall balance for code + chat (32B, 128K context)",
+    "deepseek-r1-free": "FREE: Advanced reasoning model (671B, 163K context)",
+    "mistral-devstral-free": "FREE: Code specialist (SWE-Bench 46.8%, 128K context)",
+    "gemini-flash-free": "FREE: Ultra-fast with 1M context window",
+    "llama-70b-free": "FREE: High-quality general chat (70B, 128K context)",
+    "qwq-32b-free": "FREE: Step-by-step reasoning (32B, 32K context)",
+    "nemotron-free": "FREE: NVIDIA enhanced (253B, 128K context)",
 }
 
 # Token allocation for Gemini Pro (1M total capacity)

--- a/providers/base.py
+++ b/providers/base.py
@@ -11,6 +11,7 @@ class ProviderType(Enum):
 
     GOOGLE = "google"
     OPENAI = "openai"
+    OPENROUTER = "openrouter"
 
 
 class TemperatureConstraint(ABC):

--- a/providers/openrouter.py
+++ b/providers/openrouter.py
@@ -1,0 +1,151 @@
+"""OpenRouter provider for free tier models."""
+import os
+import logging
+import aiohttp
+import json
+from typing import Optional, Dict, Any
+
+from .base import ModelProvider, ModelResponse, ProviderType
+
+logger = logging.getLogger(__name__)
+
+
+class OpenRouterModelProvider(ModelProvider):
+    """Provider for OpenRouter free tier models."""
+    
+    def __init__(self):
+        """Initialize the OpenRouter provider."""
+        super().__init__()
+        self.api_key = os.getenv("OPENROUTER_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENROUTER_API_KEY environment variable is required")
+        
+        self.base_url = "https://openrouter.ai/api/v1/chat/completions"
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "HTTP-Referer": "https://github.com/BeehiveInnovations/zen-mcp-server",
+            "X-Title": "Zen MCP Server"
+        }
+    
+    @property
+    def provider_type(self) -> ProviderType:
+        """Return the provider type."""
+        return ProviderType.OPENROUTER
+    
+    def supports_model(self, model_name: str) -> bool:
+        """Check if this provider supports the given model."""
+        # Support models ending with -free suffix
+        return model_name.endswith("-free")
+    
+    async def generate_response(
+        self,
+        model_name: str,
+        system_prompt: str,
+        user_prompt: str,
+        temperature: float = 0.7,
+        thinking_mode: Optional[str] = None,
+        **kwargs
+    ) -> ModelResponse:
+        """Generate a response using OpenRouter's free tier models."""
+        
+        # Map our simplified names to OpenRouter model IDs
+        model_mapping = {
+            "qwen-coder-free": "qwen/qwen-2.5-coder-32b-instruct:free",
+            "deepseek-r1-free": "deepseek/deepseek-r1:free",
+            "mistral-devstral-free": "mistralai/devstral-small:free",
+            "gemini-flash-free": "google/gemini-2.0-flash-exp:free",
+            "llama-70b-free": "meta-llama/llama-3.3-70b-instruct:free",
+            "qwq-32b-free": "qwen/qwq-32b:free",
+            "nemotron-free": "nvidia/llama-3.1-nemotron-ultra-253b-v1:free"
+        }
+        
+        # Get the actual model ID
+        actual_model = model_mapping.get(model_name, model_name)
+        
+        # Ensure it has :free suffix if not already present
+        if not actual_model.endswith(":free"):
+            actual_model += ":free"
+        
+        logger.debug(f"Using OpenRouter model: {actual_model}")
+        
+        # Build the request
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt}
+        ]
+        
+        request_data = {
+            "model": actual_model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": 4096  # Reasonable default for free tier
+        }
+        
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    self.base_url,
+                    headers=self.headers,
+                    json=request_data,
+                    timeout=aiohttp.ClientTimeout(total=120)
+                ) as response:
+                    
+                    if response.status == 429:
+                        # Rate limit hit
+                        return ModelResponse(
+                            content="Rate limit exceeded. Free tier models have daily limits (50-1000 requests). Try again later or use a different free model.",
+                            model_info={"error": "rate_limit", "model": actual_model}
+                        )
+                    
+                    if response.status != 200:
+                        error_text = await response.text()
+                        logger.error(f"OpenRouter API error: {response.status} - {error_text}")
+                        return ModelResponse(
+                            content=f"OpenRouter API error: {response.status}",
+                            model_info={"error": error_text}
+                        )
+                    
+                    data = await response.json()
+                    
+                    # Extract the response
+                    if "choices" in data and len(data["choices"]) > 0:
+                        content = data["choices"][0]["message"]["content"]
+                        
+                        # Handle thinking tokens if present (for models like DeepSeek R1)
+                        thinking_content = None
+                        if "thinking_content" in data["choices"][0]["message"]:
+                            thinking_content = data["choices"][0]["message"]["thinking_content"]
+                        
+                        model_info = {
+                            "model": actual_model,
+                            "usage": data.get("usage", {}),
+                            "thinking_content": thinking_content
+                        }
+                        
+                        return ModelResponse(
+                            content=content,
+                            model_info=model_info
+                        )
+                    else:
+                        return ModelResponse(
+                            content="No response from model",
+                            model_info={"error": "empty_response"}
+                        )
+                        
+        except aiohttp.ClientTimeout:
+            return ModelResponse(
+                content="Request timed out. Free tier models may be under heavy load. Try again later.",
+                model_info={"error": "timeout"}
+            )
+        except Exception as e:
+            logger.error(f"OpenRouter request failed: {str(e)}")
+            return ModelResponse(
+                content=f"Error calling OpenRouter: {str(e)}",
+                model_info={"error": str(e)}
+            )
+    
+    async def count_tokens(self, text: str, model: Optional[str] = None) -> int:
+        """Estimate token count for the given text."""
+        # Simple estimation: ~4 characters per token
+        # OpenRouter doesn't provide a token counting endpoint for free tier
+        return len(text) // 4

--- a/providers/openrouter.py
+++ b/providers/openrouter.py
@@ -15,10 +15,10 @@ class OpenRouterModelProvider(ModelProvider):
     
     def __init__(self):
         """Initialize the OpenRouter provider."""
-        super().__init__()
         self.api_key = os.getenv("OPENROUTER_API_KEY")
         if not self.api_key:
             raise ValueError("OPENROUTER_API_KEY environment variable is required")
+        super().__init__(api_key=self.api_key)
         
         self.base_url = "https://openrouter.ai/api/v1/chat/completions"
         self.headers = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ google-genai>=1.19.0
 openai>=1.0.0
 pydantic>=2.0.0
 redis>=5.0.0
+aiohttp>=3.8.0
 
 # Development dependencies
 pytest>=7.4.0

--- a/server.py
+++ b/server.py
@@ -147,6 +147,14 @@ def configure_providers():
         ModelProviderRegistry.register_provider(ProviderType.OPENAI, OpenAIModelProvider)
         valid_providers.append("OpenAI (o3)")
         logger.info("OpenAI API key found - o3 model available")
+    
+    # Check for OpenRouter API key
+    openrouter_key = os.getenv("OPENROUTER_API_KEY")
+    if openrouter_key and openrouter_key != "your_openrouter_api_key_here":
+        from providers.openrouter import OpenRouterModelProvider
+        ModelProviderRegistry.register_provider(ProviderType.OPENROUTER, OpenRouterModelProvider)
+        valid_providers.append("OpenRouter (FREE models)")
+        logger.info("OpenRouter API key found - FREE models available")
 
     # Require at least one valid provider
     if not valid_providers:

--- a/tools/base.py
+++ b/tools/base.py
@@ -1218,6 +1218,13 @@ When recommending searches, be specific about what information you need and why 
 
                 ModelProviderRegistry.register_provider(ProviderType.OPENAI, OpenAIModelProvider)
                 provider = ModelProviderRegistry.get_provider(ProviderType.OPENAI)
+            elif model_name.lower().endswith("-free"):
+                # Register OpenRouter provider if not already registered
+                from providers.base import ProviderType
+                from providers.openrouter import OpenRouterModelProvider
+
+                ModelProviderRegistry.register_provider(ProviderType.OPENROUTER, OpenRouterModelProvider)
+                provider = ModelProviderRegistry.get_provider(ProviderType.OPENROUTER)
 
         if not provider:
             raise ValueError(


### PR DESCRIPTION
- Added OpenRouter provider for free models (providers/openrouter.py)
- Added 7 free models to config.py with -free suffix
- Updated provider registry to support OpenRouter
- Added pattern matching for -free models in tools/base.py
- Updated .env.example with OPENROUTER_API_KEY
- Added aiohttp dependency for OpenRouter API calls
- Updated README with free models section and table
- Registered OpenRouter provider conditionally in server.py

This gives users access to powerful models like DeepSeek R1 (671B), Qwen 2.5 Coder, and Mistral Devstral completely FREE. No credit card required, just an OpenRouter API key.

Non-breaking change - only activates if OPENROUTER_API_KEY is set.