### PR TITLE
feat: add LOCALE support for multilingual AI responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,12 @@ DEFAULT_THINKING_MODE_THINKDEEP=high
 # The Redis URL for conversation threading - typically managed by docker-compose
 # REDIS_URL=redis://redis:6379/0
 
+# Optional: Language setting for AI responses
+# If set, AI will respond in the specified language
+# Examples: zh-TW, en-US, ja-JP, ko-KR
+# Leave empty for default (English) responses
+LOCALE=
+
 # Optional: Logging level (DEBUG, INFO, WARNING, ERROR)
 # DEBUG: Shows detailed operational messages for troubleshooting
 # INFO: Shows general operational messages (default)

--- a/README.md
+++ b/README.md
@@ -510,6 +510,24 @@ OPENAI_API_KEY=your-openai-key    # Enables O3, O3-mini
 - **`o3-mini`**: Balanced speed/quality
 - **Custom models**: via OpenRouter or local APIs (Ollama, vLLM, etc.)
 
+### Language Configuration
+
+Control the language of AI responses via the `LOCALE` environment variable:
+
+**Set in your .env file:**
+```bash
+# Examples:
+LOCALE=zh-TW    # Traditional Chinese
+LOCALE=zh-CN    # Simplified Chinese
+LOCALE=ja-JP    # Japanese
+LOCALE=ko-KR    # Korean
+LOCALE=es-ES    # Spanish
+LOCALE=fr-FR    # French
+# Leave empty for default responses
+```
+
+When set, all AI tools will respond in the specified language while maintaining their analytical capabilities.
+
 For detailed configuration options, see the [Advanced Usage Guide](docs/advanced-usage.md).
 
 ## License

--- a/config.py
+++ b/config.py
@@ -81,6 +81,12 @@ DEFAULT_THINKING_MODE_THINKDEEP = os.getenv("DEFAULT_THINKING_MODE_THINKDEEP", "
 # as files to bypass MCP's token constraints.
 MCP_PROMPT_SIZE_LIMIT = 50_000  # 50K characters
 
+# Language configuration
+# LOCALE: Language setting for AI responses
+# If set, adds language instruction to prompts (e.g., "zh-TW", "en-US")
+# Leave empty for no language instruction
+LOCALE = os.getenv("LOCALE", "")
+
 # Threading configuration
 # Simple Redis-based conversation threading for stateless MCP environment
 # Set REDIS_URL environment variable to connect to your Redis instance

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - CUSTOM_MODEL_NAME=${CUSTOM_MODEL_NAME:-llama3.2}
       - DEFAULT_MODEL=${DEFAULT_MODEL:-auto}
       - DEFAULT_THINKING_MODE_THINKDEEP=${DEFAULT_THINKING_MODE_THINKDEEP:-high}
+      - LOCALE=${LOCALE:-}
       - REDIS_URL=redis://redis:6379/0
       # Use HOME not PWD: Claude needs access to any absolute file path, not just current project,
       # and Claude Code could be running from multiple locations at the same time

--- a/tools/base.py
+++ b/tools/base.py
@@ -302,6 +302,21 @@ class BaseTool(ABC):
         """
         return "medium"  # Default to medium thinking for better reasoning
 
+    def get_language_instruction(self) -> str:
+        """
+        Generate language instruction based on LOCALE configuration.
+        
+        Returns:
+            str: Language instruction to prepend to prompt, or empty string if no locale set
+        """
+        from config import LOCALE
+        
+        if not LOCALE or not LOCALE.strip():
+            return ""
+        
+        # Simple language instruction
+        return f"Always speak in {LOCALE.strip()}.\n\n"
+
     def get_conversation_embedded_files(self, continuation_id: Optional[str]) -> list[str]:
         """
         Get list of files already embedded in conversation history.
@@ -885,7 +900,9 @@ When recommending searches, be specific about what information you need and why 
                 logger.warning(warning)
 
             # Get system prompt for this tool
-            system_prompt = self.get_system_prompt()
+            base_system_prompt = self.get_system_prompt()
+            language_instruction = self.get_language_instruction()
+            system_prompt = language_instruction + base_system_prompt
 
             # Generate AI response using the provider
             logger.info(f"Sending request to {provider.get_provider_type().value} API for {self.name}")


### PR DESCRIPTION
## Summary

This PR adds support for multilingual AI responses through a new `LOCALE` environment variable.

## Changes

- ✨ Added `LOCALE` configuration in `config.py` for language setting
- 🔧 Implemented `get_language_instruction()` method in `BaseTool` to generate language instructions
- 🌐 Modified `execute()` method to prepend language instruction to system prompts
- 📝 Updated `.env.example` with LOCALE configuration examples  
- 🐳 Added LOCALE environment variable to `docker-compose.yml`
- 📚 Documented language configuration in `README.md`

## How it works

When `LOCALE` is set (e.g., `LOCALE=zh-TW`), the system automatically prepends "Always speak in zh-TW." to all AI tool prompts, ensuring responses are in the desired language while maintaining all analytical capabilities.

## Examples

```bash
# Traditional Chinese
LOCALE=zh-TW

# Japanese  
LOCALE=ja-JP

# Spanish
LOCALE=es-ES
```

## Testing

The implementation is minimal and non-intrusive - when `LOCALE` is not set, behavior remains unchanged.

## Screenshots

N/A - This is a backend configuration change.