### PR TITLE
Fix Google model restriction parameter order (follow-up to #60)

### DIFF
--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -73,7 +73,9 @@ class GeminiModelProvider(ModelProvider):
         from utils.model_restrictions import get_restriction_service
 
         restriction_service = get_restriction_service()
-        if not restriction_service.is_allowed(ProviderType.GOOGLE, model_name, resolved_name):
+        # IMPORTANT: Parameter order is (provider_type, model_name, original_name)
+        # resolved_name is the canonical model name, model_name is the user input
+        if not restriction_service.is_allowed(ProviderType.GOOGLE, resolved_name, model_name):
             raise ValueError(f"Gemini model '{resolved_name}' is not allowed by restriction policy.")
 
         config = self.SUPPORTED_MODELS[resolved_name]
@@ -253,7 +255,9 @@ class GeminiModelProvider(ModelProvider):
         from utils.model_restrictions import get_restriction_service
 
         restriction_service = get_restriction_service()
-        if not restriction_service.is_allowed(ProviderType.GOOGLE, model_name, resolved_name):
+        # IMPORTANT: Parameter order is (provider_type, model_name, original_name)
+        # resolved_name is the canonical model name, model_name is the user input
+        if not restriction_service.is_allowed(ProviderType.GOOGLE, resolved_name, model_name):
             logger.debug(f"Gemini model '{model_name}' -> '{resolved_name}' blocked by restrictions")
             return False
 


### PR DESCRIPTION
## Summary
Fixes the parameter order regression introduced in PR #60 that was merged while still marked as WIP.

## Problem
PR #60 was merged prematurely while marked as WIP, and it swapped the `restriction_service.is_allowed()` parameters in the wrong direction, breaking Gemini model access with errors like:
```
Gemini model 'gemini-2.5-pro-preview-06-05' is not allowed by restriction policy
```

## Root Cause
The `is_allowed()` method signature is:
```python
def is_allowed(self, provider_type: ProviderType, model_name: str, original_name: Optional[str] = None) -> bool:
```

- **model_name**: Should be the canonical/resolved model name
- **original_name**: Should be the user's original input

PR #60 used `(provider_type, model_name, resolved_name)` but it should be `(provider_type, resolved_name, model_name)`.

## Solution
- Fixed parameter order in all `restriction_service.is_allowed()` calls
- Added clear comments explaining the parameter mapping to prevent future confusion
- Tested with both Gemini Flash and Pro models - now working correctly

## Test Results
✅ `mcp__zen__chat` with Gemini Flash: Working
✅ `mcp__zen__chat` with Gemini Pro: Working

## Changes
- `providers/gemini.py`: Fixed parameter order in 2 locations and added explanatory comments

This addresses the regression that occurred when PR #60 was merged while still WIP.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>