### PR TITLE
Fix Gemini token usage calculation bug causing request failures

### DIFF
--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -307,7 +307,8 @@ class GeminiModelProvider(ModelProvider):
                 usage["input_tokens"] = metadata.prompt_token_count
             if hasattr(metadata, "candidates_token_count"):
                 usage["output_tokens"] = metadata.candidates_token_count
-            if "input_tokens" in usage and "output_tokens" in usage:
+            if ("input_tokens" in usage and "output_tokens" in usage and 
+                usage["input_tokens"] is not None and usage["output_tokens"] is not None):
                 usage["total_tokens"] = usage["input_tokens"] + usage["output_tokens"]
 
         return usage


### PR DESCRIPTION
## Summary
- Fixed critical TypeError in Gemini provider's `_extract_usage` method
- Added null checks before calculating `total_tokens` to handle None values from API
- Resolves hanging requests on Vast AI VM instances and other environments

## Test plan
- [x] Tested with direct API calls using debug script
- [x] Verified fix resolves hanging connection issues
- [x] Server restart confirms proper functionality
- [x] Code review completed using Gemini Pro model

## Details
The `_extract_usage` method was attempting to add `input_tokens + output_tokens` without checking for None values. When Google's API returned None for token counts, this caused a TypeError that made requests appear to hang.

**Before:**
```python
if "input_tokens" in usage and "output_tokens" in usage:
    usage["total_tokens"] = usage["input_tokens"] + usage["output_tokens"]
```

**After:**
```python
if ("input_tokens" in usage and "output_tokens" in usage and 
    usage["input_tokens"] is not None and usage["output_tokens"] is not None):
    usage["total_tokens"] = usage["input_tokens"] + usage["output_tokens"]
```

## Code Review Feedback
Gemini Pro model provided additional suggestions for improvement:
- Refactor `_extract_usage` to enforce type hints more strictly
- Consolidate vision support logic to eliminate code duplication
- Move local imports to top of file

These improvements can be addressed in a follow-up PR if desired.

🤖 Generated with [Claude Code](https://claude.ai/code)