### PR TITLE
fix: update open router model name for Gemini

### DIFF
--- a/conf/custom_models.json
+++ b/conf/custom_models.json
@@ -82,7 +82,7 @@
       "description": "Claude 3 Haiku - Fast and efficient with vision"
     },
     {
-      "model_name": "google/gemini-2.5-pro-preview",
+      "model_name": "google/gemini-2.5-pro",
       "aliases": ["pro","gemini-pro", "gemini", "pro-openrouter"],
       "context_window": 1048576,
       "supports_extended_thinking": false,


### PR DESCRIPTION

## Description

Fixing broken open router model name #98 
## Changes Made

- Changed model name from `google/gemini-2.5-pro-preview` to `google/gemini-2.5-pro` to reflect updated OpenRouter model names

## Testing

**Please review our [Testing Guide](../docs/testing.md) before submitting.**

### Run all linting and tests (required):
```bash
# Activate virtual environment first
source venv/bin/activate

# Run comprehensive code quality checks (recommended)
./code_quality_checks.sh

# If you made tool changes, also run simulator tests
python communication_simulator_test.py
```

- [x] All linting passes (ruff, black, isort)
- [x] All unit tests pass
- [x] **For new features**: Unit tests added in `tests/`
- [ ] **For tool changes**: Simulator tests added in `simulator_tests/`
- [ ] **For bug fixes**: Tests added to prevent regression
- [ ] Simulator tests pass (if applicable)
- [ ] Manual testing completed with realistic scenarios

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] PR title follows the format guidelines above
- [ ] **Activated venv and ran code quality checks: `source venv/bin/activate && ./code_quality_checks.sh`**
- [ ] Self-review completed
- [ ] **Tests added for ALL changes** (see Testing section above)
- [ ] Documentation updated as needed
- [ ] All unit tests passing
- [ ] Relevant simulator tests passing (if tool changes)
- [ ] Ready for review

## Additional Notes

Any additional information that reviewers should know.