### PR TITLE
fix: properly handle Unicode characters in JSON output

### DIFF
--- a/tools/consensus.py
+++ b/tools/consensus.py
@@ -512,7 +512,7 @@ of the evidence, even when it strongly points in one direction.""",
                     "provider_used": provider.get_provider_type().value,
                 }
 
-                return [TextContent(type="text", text=json.dumps(response_data, indent=2))]
+                return [TextContent(type="text", text=json.dumps(response_data, indent=2, ensure_ascii=False))]
 
         # Otherwise, use standard workflow execution
         return await super().execute_workflow(arguments)

--- a/tools/simple/base.py
+++ b/tools/simple/base.py
@@ -395,7 +395,7 @@ class SimpleTool(BaseTool):
                     images, model_context=self._model_context, continuation_id=continuation_id
                 )
                 if image_validation_error:
-                    return [TextContent(type="text", text=json.dumps(image_validation_error))]
+                    return [TextContent(type="text", text=json.dumps(image_validation_error, ensure_ascii=False))]
 
             # Get and validate temperature against model constraints
             temperature, temp_warnings = self.get_validated_temperature(request, self._model_context)

--- a/tools/workflow/workflow_mixin.py
+++ b/tools/workflow/workflow_mixin.py
@@ -715,7 +715,7 @@ class BaseWorkflowMixin(ABC):
             if continuation_id:
                 self.store_conversation_turn(continuation_id, response_data, request)
 
-            return [TextContent(type="text", text=json.dumps(response_data, indent=2))]
+            return [TextContent(type="text", text=json.dumps(response_data, indent=2, ensure_ascii=False))]
 
         except Exception as e:
             logger.error(f"Error in {self.get_name()} work: {e}", exc_info=True)
@@ -728,7 +728,7 @@ class BaseWorkflowMixin(ABC):
             # Add metadata to error responses too
             self._add_workflow_metadata(error_data, arguments)
 
-            return [TextContent(type="text", text=json.dumps(error_data, indent=2))]
+            return [TextContent(type="text", text=json.dumps(error_data, indent=2, ensure_ascii=False))]
 
     # Hook methods for tool customization
 
@@ -1233,7 +1233,7 @@ class BaseWorkflowMixin(ABC):
         # - file_context (internal optimization info)
         # - required_actions (internal workflow instructions)
 
-        return json.dumps(clean_data, indent=2)
+        return json.dumps(clean_data, indent=2, ensure_ascii=False)
 
     # Core workflow logic methods
 
@@ -1265,7 +1265,7 @@ class BaseWorkflowMixin(ABC):
                 # Promote the special status to the main response
                 special_status = expert_analysis["status"]
                 response_data["status"] = special_status
-                response_data["content"] = expert_analysis.get("raw_analysis", json.dumps(expert_analysis))
+                response_data["content"] = expert_analysis.get("raw_analysis", json.dumps(expert_analysis, ensure_ascii=False))
                 del response_data["expert_analysis"]
 
                 # Update next steps for special status
@@ -1524,7 +1524,7 @@ class BaseWorkflowMixin(ABC):
                 error_data = {"status": "error", "content": "No arguments provided"}
                 # Add basic metadata even for validation errors
                 error_data["metadata"] = {"tool_name": self.get_name()}
-                return [TextContent(type="text", text=json.dumps(error_data))]
+                return [TextContent(type="text", text=json.dumps(error_data, ensure_ascii=False))]
 
             # Delegate to execute_workflow
             return await self.execute_workflow(arguments)
@@ -1537,7 +1537,7 @@ class BaseWorkflowMixin(ABC):
             return [
                 TextContent(
                     type="text",
-                    text=json.dumps(error_data),
+                    text=json.dumps(error_data, ensure_ascii=False),
                 )
             ]
 


### PR DESCRIPTION
## Summary
Fixes Unicode encoding issues where Chinese and other non-ASCII characters display as escape sequences (e.g., `\u5efa\u8bae` instead of `建议`) in workflow tool outputs.

## Problem Analysis
**Root Cause: Inconsistent JSON serialization approaches**

The codebase uses two different JSON serialization patterns:
- **SimpleTool**: Uses `model_dump_json()` (Pydantic) → ✅ Correctly handles Unicode
- **WorkflowTool**: Uses `json.dumps()` (Python stdlib) → ❌ Defaults to `ensure_ascii=True`

**Why chat tool works but consensus/workflow tools don't:**
- Chat tool inherits from `SimpleTool` → uses `tool_output.model_dump_json()`
- Consensus tool inherits from `WorkflowTool` → uses `json.dumps()` without `ensure_ascii=False`

## Changes Made
Added `ensure_ascii=False` parameter to all `json.dumps()` calls in tool outputs:

- **tools/consensus.py:515** - Main consensus output
- **tools/workflow/workflow_mixin.py:718** - Workflow response output  
- **tools/workflow/workflow_mixin.py:731** - Workflow error output
- **tools/workflow/workflow_mixin.py:1236** - Internal JSON formatting
- **tools/workflow/workflow_mixin.py:1268** - Expert analysis content
- **tools/workflow/workflow_mixin.py:1527** - Validation error output
- **tools/workflow/workflow_mixin.py:1540** - General error output
- **tools/simple/base.py:398** - Image validation error output

## Impact Assessment
✅ **Non-breaking change**: JSON content remains semantically identical
✅ **Improved UX**: Better display for international users  
✅ **Standards compliant**: Follows modern UTF-8 practices
✅ **Minimal risk**: Only affects visual representation, not functionality

## Future Considerations
This is a **temporary fix** for a deeper architectural inconsistency:

**Long-term solution needed:**
- Standardize JSON serialization across the codebase
- Consider unified approach: either all `model_dump_json()` or consistent `json.dumps()` configuration
- Establish coding standards for new tool development

**Recommended next steps:**
1. Create architectural guidelines for JSON output formatting
2. Consider refactoring to use consistent Pydantic response models
3. Add linting rules to catch `json.dumps()` without `ensure_ascii=False`

## Testing
- ✅ Verified with Chinese input: characters now display correctly
- ✅ Tested consensus tool: Unicode escapes resolved
- ✅ Backward compatibility: JSON parsing remains identical
- ✅ No functional changes: only display improvement

## Related Issues
Resolves Unicode display issues for international users, particularly impacting:
- Chinese language users
- Any non-ASCII character sets (Arabic, Cyrillic, etc.)
- Workflow tools: consensus, codereview, analyze, debug, etc.

---
**Type**: Bug fix  
**Priority**: Medium  
**Affects**: All workflow tools when handling non-ASCII characters