### PR TITLE
fix: WSL script crash when wslvar command unavailable

### DIFF
--- a/run-server.sh
+++ b/run-server.sh
@@ -125,7 +125,7 @@ get_claude_config_path() {
                 win_appdata=$(wslvar APPDATA 2>/dev/null)
             fi
             
-            if [[ -n "$win_appdata" ]]; then
+            if [[ "${win_appdata:-}" != "" ]]; then
                 echo "$(wslpath "$win_appdata")/Claude/claude_desktop_config.json"
             else
                 print_warning "Could not determine Windows user path automatically. Please ensure APPDATA is set correctly or provide the full path manually."


### PR DESCRIPTION
## Description

Fixes a script crash on WSL systems when the `wslvar` command is not installed. The script fails with "unbound variable" error due to `set -euo pipefail` when trying to check an uninitialized variable.

## Changes Made

- [x] Fixed unbound variable error in `get_claude_config_path()` function
- [x] Changed `[[ -n "$win_appdata" ]]` to `[[ -n "${win_appdata:-}" ]]` to safely handle unset variables
- [x] No behavioral changes - script continues with same logic flow and fallback paths

## Testing

**Please review our [Testing Guide](../docs/testing.md) before submitting.**

### Run all linting and tests (required):
```bash
# Activate virtual environment first
source venv/bin/activate

# Run comprehensive code quality checks (recommended)
./code_quality_checks.sh

```
🔍 Running Code Quality Checks for Zen MCP Server
=================================================
✅ Using venv

🔍 Checking development dependencies...
✅ Development dependencies already installed

📋 Step 1: Running Linting and Formatting Checks
--------------------------------------------------
🔧 Running ruff linting with auto-fix...
All checks passed!
🎨 Running black code formatting...
All done! ✨ 🍰 ✨
184 files left unchanged.
📦 Running import sorting with isort...
Skipped 8 files
✅ Verifying all linting passes...
All checks passed!
✅ Step 1 Complete: All linting and formatting checks passed!

🧪 Step 2: Running Complete Unit Test Suite
---------------------------------------------
🏃 Running unit tests (excluding integration tests)...
.....
✅ Step 2 Complete: All unit tests passed!

🎉 All Code Quality Checks Passed!
==================================
✅ Linting (ruff): PASSED
✅ Formatting (black): PASSED
✅ Import sorting (isort): PASSED
✅ Unit tests: PASSED

🚀 Your code is ready for commit and GitHub Actions!
💡 Remember to add simulator tests if you modified tools
```

## Related Issues

Fixes #173 

## Checklist

- [X] PR title follows the format guidelines above
- [X] **Activated venv and ran code quality checks: `source venv/bin/activate && ./code_quality_checks.sh`**
- [X] Self-review completed
- [--] **Tests added for ALL changes** (see Testing section above) [There are no tests for `run-server.sh`]
- [X] Documentation updated as needed
- [ ] Relevant simulator tests passing (if tool changes)
- [X] Ready for review

## Additional Notes

Any additional information that reviewers should know.