### PR TITLE
feat: Add support for OpenAI GPT-5 series models

### DIFF
--- a/providers/openai_provider.py
+++ b/providers/openai_provider.py
@@ -109,6 +109,60 @@ class OpenAIModelProvider(OpenAICompatibleProvider):
             description="GPT-4.1 (1M context) - Advanced reasoning model with large context window",
             aliases=["gpt4.1"],
         ),
+        "gpt-5": ModelCapabilities(
+            provider=ProviderType.OPENAI,
+            model_name="gpt-5",
+            friendly_name="OpenAI (GPT-5)",
+            context_window=400_000,  # 400K tokens total
+            max_output_tokens=128_000,  # 128K max output tokens
+            supports_extended_thinking=True,  # Supports reasoning tokens
+            supports_system_prompts=True,
+            supports_streaming=True,
+            supports_function_calling=True,
+            supports_json_mode=True,
+            supports_images=True,  # Supports text and image
+            max_image_size_mb=20.0,
+            supports_temperature=True,
+            temperature_constraint=create_temperature_constraint("range"),
+            description="GPT-5 (400K context) - The best model for coding and agentic tasks across domains",
+            aliases=["gpt5"],
+        ),
+        "gpt-5-mini": ModelCapabilities(
+            provider=ProviderType.OPENAI,
+            model_name="gpt-5-mini",
+            friendly_name="OpenAI (GPT-5 mini)",
+            context_window=400_000,  # 400K tokens total
+            max_output_tokens=128_000,  # 128K max output tokens
+            supports_extended_thinking=True,  # Supports reasoning tokens
+            supports_system_prompts=True,
+            supports_streaming=True,
+            supports_function_calling=True,
+            supports_json_mode=True,
+            supports_images=True,  # Supports text and image
+            max_image_size_mb=20.0,
+            supports_temperature=True,
+            temperature_constraint=create_temperature_constraint("range"),
+            description="GPT-5 mini (400K context) - A faster, more cost-efficient version of GPT-5 for well-defined tasks",
+            aliases=["gpt5mini", "gpt5-mini"],
+        ),
+        "gpt-5-nano": ModelCapabilities(
+            provider=ProviderType.OPENAI,
+            model_name="gpt-5-nano",
+            friendly_name="OpenAI (GPT-5 nano)",
+            context_window=400_000,  # 400K tokens total
+            max_output_tokens=128_000,  # 128K max output tokens
+            supports_extended_thinking=True,  # Supports reasoning tokens
+            supports_system_prompts=True,
+            supports_streaming=True,
+            supports_function_calling=True,
+            supports_json_mode=True,
+            supports_images=True,  # Supports text and image
+            max_image_size_mb=20.0,
+            supports_temperature=True,
+            temperature_constraint=create_temperature_constraint("range"),
+            description="GPT-5 nano (400K context) - Fastest, cheapest version of GPT-5 for summarization and classification tasks",
+            aliases=["gpt5nano", "gpt5-nano"],
+        ),
     }
 
     def __init__(self, api_key: str, **kwargs):


### PR DESCRIPTION
## Summary
This PR adds support for the new OpenAI GPT-5 series models that were released on August 7, 2025.

## Changes
- Added GPT-5, GPT-5-mini, and GPT-5-nano model configurations to `providers/openai_provider.py`
- Each model includes proper context windows, output tokens, and feature support flags

## Models Added
| Model | Context | Output | Description |
|-------|---------|--------|-------------|
| `gpt-5` | 400K | 128K | Flagship model for coding and agentic tasks |
| `gpt-5-mini` | 400K | 128K | Faster, cost-efficient variant |
| `gpt-5-nano` | 400K | 128K | Fastest variant for summarization/classification |

## Features
All models support:
- ✅ Extended thinking/reasoning capabilities
- ✅ Image processing
- ✅ Function calling and JSON mode
- ✅ Temperature control
- ✅ Streaming responses

## Pricing
- **GPT-5**: $1.25/1M input, $10/1M output tokens
- **GPT-5-mini**: $0.25/1M input, $2/1M output tokens
- **GPT-5-nano**: $0.05/1M input, $0.40/1M output tokens

## Testing
Models were configured based on official OpenAI documentation and screenshots provided by the user.

Fixes #212

🤖 Generated with [Claude Code](https://claude.ai/code)