### PR TITLE
feat(auth): add ChatGPT login mode for OpenAI authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,15 @@ GEMINI_API_KEY=your_gemini_api_key_here
 # Get your OpenAI API key from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=your_openai_api_key_here
 
+# Optional: Use ChatGPT login tokens instead of OpenAI API key
+# When enabled, the server will prioritize ChatGPT authentication tokens from ~/.codex/auth.json
+# over the OPENAI_API_KEY above. This allows using your ChatGPT Pro subscription tokens.
+# Requirements: 
+#   - Valid ChatGPT Pro subscription with Codex access
+#   - ~/.codex/auth.json file with valid tokens (access_token, account_id)
+# Set to 'true' to enable, 'false' or leave empty to disable (default)
+OPENAI_CHATGPT_LOGIN_MODE=false
+
 # Get your X.AI API key from: https://console.x.ai/
 XAI_API_KEY=your_xai_api_key_here
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For best results, use Claude Code with:
 **1. Get API Keys** (choose one or more):
 - **[OpenRouter](https://openrouter.ai/)** - Access multiple models with one API
 - **[Gemini](https://makersuite.google.com/app/apikey)** - Google's latest models
-- **[OpenAI](https://platform.openai.com/api-keys)** - O3, GPT-5 series
+- **[OpenAI](https://platform.openai.com/api-keys)** - O3, GPT-5 series. **Alternative**: Enable `OPENAI_CHATGPT_LOGIN_MODE=true` to use your existing ChatGPT Pro subscription tokens instead of an API key
 - **[X.AI](https://console.x.ai/)** - Grok models
 - **[DIAL](https://dialx.ai/)** - Vendor-agnostic model access
 - **[Ollama](https://ollama.ai/)** - Local models (free)

--- a/providers/openai_provider.py
+++ b/providers/openai_provider.py
@@ -171,7 +171,7 @@ class OpenAIModelProvider(OpenAICompatibleProvider):
     def __init__(self, api_key: str, **kwargs):
         """Initialize OpenAI provider with API key."""
         from utils.chatgpt_auth import get_valid_chatgpt_auth
-        
+
         # Check if using ChatGPT mode
         chatgpt_auth = get_valid_chatgpt_auth()
         if chatgpt_auth and api_key == chatgpt_auth.access_token:
@@ -179,15 +179,15 @@ class OpenAIModelProvider(OpenAICompatibleProvider):
             kwargs.setdefault("base_url", "https://chatgpt.com/backend-api/codex/")
             # Set ChatGPT-specific headers as DEFAULT_HEADERS
             self.DEFAULT_HEADERS = {
-                'Content-Type': 'application/json',
-                'Authorization': f'Bearer {chatgpt_auth.access_token}',
-                'originator': 'codex_cli_rs',
-                'chatgpt-account-id': chatgpt_auth.account_id
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {chatgpt_auth.access_token}",
+                "originator": "codex_cli_rs",
+                "chatgpt-account-id": chatgpt_auth.account_id,
             }
         else:
             # Standard OpenAI API
             kwargs.setdefault("base_url", "https://api.openai.com/v1")
-        
+
         super().__init__(api_key, **kwargs)
 
     def get_capabilities(self, model_name: str) -> ModelCapabilities:

--- a/server.py
+++ b/server.py
@@ -407,15 +407,15 @@ def configure_providers():
 
     # Check for OpenAI authentication (ChatGPT login mode takes priority)
     from utils.chatgpt_auth import get_valid_chatgpt_auth
-    
+
     openai_auth_available = False
-    
+
     # Check ChatGPT login mode first
     chatgpt_auth = get_valid_chatgpt_auth()
     if chatgpt_auth:
         openai_auth_available = True
         logger.info("ChatGPT authentication found - OpenAI models available")
-    
+
     # Fallback to API key if ChatGPT mode not available
     if not openai_auth_available:
         openai_key = os.getenv("OPENAI_API_KEY")
@@ -428,7 +428,7 @@ def configure_providers():
                 logger.debug("OpenAI API key not found in environment")
             else:
                 logger.debug("OpenAI API key is placeholder value")
-    
+
     if openai_auth_available:
         valid_providers.append("OpenAI")
         has_native_apis = True
@@ -488,6 +488,7 @@ def configure_providers():
                 # Use ChatGPT access token
                 def openai_chatgpt_factory(api_key=None):
                     return OpenAIModelProvider(chatgpt_auth.access_token)
+
                 ModelProviderRegistry.register_provider(ProviderType.OPENAI, openai_chatgpt_factory)
             else:
                 # Use standard API key

--- a/tests/test_chatgpt_auth.py
+++ b/tests/test_chatgpt_auth.py
@@ -1,0 +1,227 @@
+"""Tests for ChatGPT authentication utilities."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, mock_open
+
+import pytest
+
+from utils.chatgpt_auth import ChatGPTAuth, get_chatgpt_auth, is_chatgpt_mode_enabled, get_valid_chatgpt_auth
+
+
+class TestChatGPTAuth:
+    """Test ChatGPTAuth dataclass."""
+
+    def test_valid_auth(self):
+        """Test valid authentication data."""
+        auth = ChatGPTAuth(
+            access_token="access_123",
+            account_id="account_456",
+            refresh_token="refresh_789",
+            id_token="id_abc",
+            last_refresh="2025-01-01T00:00:00Z"
+        )
+        assert auth.is_valid() is True
+
+    def test_invalid_auth_missing_access_token(self):
+        """Test invalid auth with missing access token."""
+        auth = ChatGPTAuth(
+            access_token="",
+            account_id="account_456",
+            refresh_token="refresh_789",
+            id_token="id_abc",
+            last_refresh="2025-01-01T00:00:00Z"
+        )
+        assert auth.is_valid() is False
+
+    def test_invalid_auth_missing_account_id(self):
+        """Test invalid auth with missing account ID."""
+        auth = ChatGPTAuth(
+            access_token="access_123",
+            account_id="",
+            refresh_token="refresh_789",
+            id_token="id_abc",
+            last_refresh="2025-01-01T00:00:00Z"
+        )
+        assert auth.is_valid() is False
+
+
+class TestGetChatGPTAuth:
+    """Test get_chatgpt_auth function."""
+
+    def test_auth_file_not_exists(self):
+        """Test when auth file doesn't exist."""
+        with patch('pathlib.Path.exists', return_value=False):
+            result = get_chatgpt_auth()
+            assert result is None
+
+    def test_auth_file_valid_data(self):
+        """Test with valid auth file data."""
+        auth_data = {
+            "tokens": {
+                "access_token": "access_123",
+                "account_id": "account_456",
+                "refresh_token": "refresh_789",
+                "id_token": "id_abc"
+            },
+            "last_refresh": "2025-01-01T00:00:00Z"
+        }
+        
+        with patch('pathlib.Path.exists', return_value=True):
+            with patch('builtins.open', mock_open(read_data=json.dumps(auth_data))):
+                result = get_chatgpt_auth()
+                
+                assert result is not None
+                assert result.access_token == "access_123"
+                assert result.account_id == "account_456"
+                assert result.refresh_token == "refresh_789"
+                assert result.id_token == "id_abc"
+                assert result.last_refresh == "2025-01-01T00:00:00Z"
+
+    def test_auth_file_missing_tokens(self):
+        """Test with auth file missing tokens section."""
+        auth_data = {"last_refresh": "2025-01-01T00:00:00Z"}
+        
+        with patch('pathlib.Path.exists', return_value=True):
+            with patch('builtins.open', mock_open(read_data=json.dumps(auth_data))):
+                result = get_chatgpt_auth()
+                
+                assert result is not None
+                assert result.access_token == ""
+                assert result.account_id == ""
+
+    def test_auth_file_invalid_json(self):
+        """Test with invalid JSON in auth file."""
+        with patch('pathlib.Path.exists', return_value=True):
+            with patch('builtins.open', mock_open(read_data="invalid json")):
+                result = get_chatgpt_auth()
+                assert result is None
+
+    def test_auth_file_read_error(self):
+        """Test with file read error."""
+        with patch('pathlib.Path.exists', return_value=True):
+            with patch('builtins.open', side_effect=IOError("Read error")):
+                result = get_chatgpt_auth()
+                assert result is None
+
+
+class TestIsChatGPTModeEnabled:
+    """Test is_chatgpt_mode_enabled function."""
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
+    def test_mode_enabled_true(self):
+        """Test when mode is enabled with 'true'."""
+        assert is_chatgpt_mode_enabled() is True
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "TRUE"})
+    def test_mode_enabled_uppercase(self):
+        """Test when mode is enabled with 'TRUE'."""
+        assert is_chatgpt_mode_enabled() is True
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "false"})
+    def test_mode_disabled_false(self):
+        """Test when mode is disabled with 'false'."""
+        assert is_chatgpt_mode_enabled() is False
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "invalid"})
+    def test_mode_disabled_invalid(self):
+        """Test when mode has invalid value."""
+        assert is_chatgpt_mode_enabled() is False
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_mode_not_set(self):
+        """Test when environment variable is not set."""
+        assert is_chatgpt_mode_enabled() is False
+
+
+class TestGetValidChatGPTAuth:
+    """Test get_valid_chatgpt_auth function."""
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "false"})
+    def test_mode_disabled(self):
+        """Test when ChatGPT mode is disabled."""
+        result = get_valid_chatgpt_auth()
+        assert result is None
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
+    def test_mode_enabled_no_auth_file(self):
+        """Test when mode is enabled but no auth file."""
+        with patch('pathlib.Path.exists', return_value=False):
+            result = get_valid_chatgpt_auth()
+            assert result is None
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
+    def test_mode_enabled_valid_auth(self):
+        """Test when mode is enabled with valid auth."""
+        auth_data = {
+            "tokens": {
+                "access_token": "access_123",
+                "account_id": "account_456",
+                "refresh_token": "refresh_789",
+                "id_token": "id_abc"
+            },
+            "last_refresh": "2025-01-01T00:00:00Z"
+        }
+        
+        with patch('pathlib.Path.exists', return_value=True):
+            with patch('builtins.open', mock_open(read_data=json.dumps(auth_data))):
+                result = get_valid_chatgpt_auth()
+                
+                assert result is not None
+                assert result.access_token == "access_123"
+                assert result.account_id == "account_456"
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
+    def test_mode_enabled_invalid_auth(self):
+        """Test when mode is enabled but auth is invalid."""
+        auth_data = {
+            "tokens": {
+                "access_token": "",  # Empty access token
+                "account_id": "account_456",
+                "refresh_token": "refresh_789",
+                "id_token": "id_abc"
+            },
+            "last_refresh": "2025-01-01T00:00:00Z"
+        }
+        
+        with patch('pathlib.Path.exists', return_value=True):
+            with patch('builtins.open', mock_open(read_data=json.dumps(auth_data))):
+                result = get_valid_chatgpt_auth()
+                assert result is None
+
+
+class TestIntegration:
+    """Integration tests for ChatGPT auth functionality."""
+
+    def test_real_file_system(self):
+        """Test with real file system operations."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a temporary auth file
+            codex_dir = Path(temp_dir) / ".codex"
+            codex_dir.mkdir()
+            auth_file = codex_dir / "auth.json"
+            
+            auth_data = {
+                "tokens": {
+                    "access_token": "real_access_token",
+                    "account_id": "real_account_id",
+                    "refresh_token": "real_refresh_token",
+                    "id_token": "real_id_token"
+                },
+                "last_refresh": "2025-01-01T12:00:00Z"
+            }
+            
+            with open(auth_file, 'w') as f:
+                json.dump(auth_data, f)
+            
+            # Mock Path.home() to return our temp directory
+            with patch('pathlib.Path.home', return_value=Path(temp_dir)):
+                with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
+                    result = get_valid_chatgpt_auth()
+                    
+                    assert result is not None
+                    assert result.access_token == "real_access_token"
+                    assert result.account_id == "real_account_id"
+                    assert result.is_valid() is True

--- a/tests/test_chatgpt_auth.py
+++ b/tests/test_chatgpt_auth.py
@@ -21,7 +21,7 @@ class TestChatGPTAuth:
             account_id="account_456",
             refresh_token="refresh_789",
             id_token="id_abc",
-            last_refresh="2025-01-01T00:00:00Z"
+            last_refresh="2025-01-01T00:00:00Z",
         )
         assert auth.is_valid() is True
 
@@ -32,7 +32,7 @@ class TestChatGPTAuth:
             account_id="account_456",
             refresh_token="refresh_789",
             id_token="id_abc",
-            last_refresh="2025-01-01T00:00:00Z"
+            last_refresh="2025-01-01T00:00:00Z",
         )
         assert auth.is_valid() is False
 
@@ -43,7 +43,7 @@ class TestChatGPTAuth:
             account_id="",
             refresh_token="refresh_789",
             id_token="id_abc",
-            last_refresh="2025-01-01T00:00:00Z"
+            last_refresh="2025-01-01T00:00:00Z",
         )
         assert auth.is_valid() is False
 
@@ -53,7 +53,7 @@ class TestGetChatGPTAuth:
 
     def test_auth_file_not_exists(self):
         """Test when auth file doesn't exist."""
-        with patch('pathlib.Path.exists', return_value=False):
+        with patch("pathlib.Path.exists", return_value=False):
             result = get_chatgpt_auth()
             assert result is None
 
@@ -64,15 +64,15 @@ class TestGetChatGPTAuth:
                 "access_token": "access_123",
                 "account_id": "account_456",
                 "refresh_token": "refresh_789",
-                "id_token": "id_abc"
+                "id_token": "id_abc",
             },
-            "last_refresh": "2025-01-01T00:00:00Z"
+            "last_refresh": "2025-01-01T00:00:00Z",
         }
-        
-        with patch('pathlib.Path.exists', return_value=True):
-            with patch('builtins.open', mock_open(read_data=json.dumps(auth_data))):
+
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=json.dumps(auth_data))):
                 result = get_chatgpt_auth()
-                
+
                 assert result is not None
                 assert result.access_token == "access_123"
                 assert result.account_id == "account_456"
@@ -83,26 +83,26 @@ class TestGetChatGPTAuth:
     def test_auth_file_missing_tokens(self):
         """Test with auth file missing tokens section."""
         auth_data = {"last_refresh": "2025-01-01T00:00:00Z"}
-        
-        with patch('pathlib.Path.exists', return_value=True):
-            with patch('builtins.open', mock_open(read_data=json.dumps(auth_data))):
+
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=json.dumps(auth_data))):
                 result = get_chatgpt_auth()
-                
+
                 assert result is not None
                 assert result.access_token == ""
                 assert result.account_id == ""
 
     def test_auth_file_invalid_json(self):
         """Test with invalid JSON in auth file."""
-        with patch('pathlib.Path.exists', return_value=True):
-            with patch('builtins.open', mock_open(read_data="invalid json")):
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data="invalid json")):
                 result = get_chatgpt_auth()
                 assert result is None
 
     def test_auth_file_read_error(self):
         """Test with file read error."""
-        with patch('pathlib.Path.exists', return_value=True):
-            with patch('builtins.open', side_effect=IOError("Read error")):
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("builtins.open", side_effect=IOError("Read error")):
                 result = get_chatgpt_auth()
                 assert result is None
 
@@ -148,7 +148,7 @@ class TestGetValidChatGPTAuth:
     @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
     def test_mode_enabled_no_auth_file(self):
         """Test when mode is enabled but no auth file."""
-        with patch('pathlib.Path.exists', return_value=False):
+        with patch("pathlib.Path.exists", return_value=False):
             result = get_valid_chatgpt_auth()
             assert result is None
 
@@ -160,15 +160,15 @@ class TestGetValidChatGPTAuth:
                 "access_token": "access_123",
                 "account_id": "account_456",
                 "refresh_token": "refresh_789",
-                "id_token": "id_abc"
+                "id_token": "id_abc",
             },
-            "last_refresh": "2025-01-01T00:00:00Z"
+            "last_refresh": "2025-01-01T00:00:00Z",
         }
-        
-        with patch('pathlib.Path.exists', return_value=True):
-            with patch('builtins.open', mock_open(read_data=json.dumps(auth_data))):
+
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=json.dumps(auth_data))):
                 result = get_valid_chatgpt_auth()
-                
+
                 assert result is not None
                 assert result.access_token == "access_123"
                 assert result.account_id == "account_456"
@@ -181,13 +181,13 @@ class TestGetValidChatGPTAuth:
                 "access_token": "",  # Empty access token
                 "account_id": "account_456",
                 "refresh_token": "refresh_789",
-                "id_token": "id_abc"
+                "id_token": "id_abc",
             },
-            "last_refresh": "2025-01-01T00:00:00Z"
+            "last_refresh": "2025-01-01T00:00:00Z",
         }
-        
-        with patch('pathlib.Path.exists', return_value=True):
-            with patch('builtins.open', mock_open(read_data=json.dumps(auth_data))):
+
+        with patch("pathlib.Path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=json.dumps(auth_data))):
                 result = get_valid_chatgpt_auth()
                 assert result is None
 
@@ -202,25 +202,25 @@ class TestIntegration:
             codex_dir = Path(temp_dir) / ".codex"
             codex_dir.mkdir()
             auth_file = codex_dir / "auth.json"
-            
+
             auth_data = {
                 "tokens": {
                     "access_token": "real_access_token",
                     "account_id": "real_account_id",
                     "refresh_token": "real_refresh_token",
-                    "id_token": "real_id_token"
+                    "id_token": "real_id_token",
                 },
-                "last_refresh": "2025-01-01T12:00:00Z"
+                "last_refresh": "2025-01-01T12:00:00Z",
             }
-            
-            with open(auth_file, 'w') as f:
+
+            with open(auth_file, "w") as f:
                 json.dump(auth_data, f)
-            
+
             # Mock Path.home() to return our temp directory
-            with patch('pathlib.Path.home', return_value=Path(temp_dir)):
+            with patch("pathlib.Path.home", return_value=Path(temp_dir)):
                 with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
                     result = get_valid_chatgpt_auth()
-                    
+
                     assert result is not None
                     assert result.access_token == "real_access_token"
                     assert result.account_id == "real_account_id"

--- a/tests/test_chatgpt_auth.py
+++ b/tests/test_chatgpt_auth.py
@@ -4,11 +4,9 @@ import json
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
-import pytest
-
-from utils.chatgpt_auth import ChatGPTAuth, get_chatgpt_auth, is_chatgpt_mode_enabled, get_valid_chatgpt_auth
+from utils.chatgpt_auth import ChatGPTAuth, get_chatgpt_auth, get_valid_chatgpt_auth, is_chatgpt_mode_enabled
 
 
 class TestChatGPTAuth:
@@ -102,7 +100,7 @@ class TestGetChatGPTAuth:
     def test_auth_file_read_error(self):
         """Test with file read error."""
         with patch("pathlib.Path.exists", return_value=True):
-            with patch("builtins.open", side_effect=IOError("Read error")):
+            with patch("builtins.open", side_effect=OSError("Read error")):
                 result = get_chatgpt_auth()
                 assert result is None
 

--- a/tests/test_chatgpt_functional.py
+++ b/tests/test_chatgpt_functional.py
@@ -19,7 +19,7 @@ class TestChatGPTFunctional:
             codex_dir = Path(temp_dir) / ".codex"
             codex_dir.mkdir()
             auth_file = codex_dir / "auth.json"
-            
+
             # Use realistic auth data structure (based on user's example)
             auth_data = {
                 "OPENAI_API_KEY": None,
@@ -27,19 +27,19 @@ class TestChatGPTFunctional:
                     "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImIxZGQzZjhmLTlhYWQtNDdmZS1iMGU3LWVkYjAwOTc3N2Q2YiIsInR5cCI6IkpXVCJ9...",
                     "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE5MzQ0ZTY1LWJiYzktNDRkMS1hOWQwLWY5NTdiMDc5YmQwZSIsInR5cCI6IkpXVCJ9...",
                     "refresh_token": "rt_Q5_RJlnifFDOFXQ2UxJYjJRIcDvDHj1wdR2ZVAtvSVc.aaFuBDVHEN-T-O1ndmpzLEqtzTl3xgJmTl8pT4T2e5w",
-                    "account_id": "f213aaef-b15f-4084-a2c9-e5e1b54ba05c"
+                    "account_id": "f213aaef-b15f-4084-a2c9-e5e1b54ba05c",
                 },
-                "last_refresh": "2025-08-08T23:04:28.373728Z"
+                "last_refresh": "2025-08-08T23:04:28.373728Z",
             }
-            
-            with open(auth_file, 'w') as f:
+
+            with open(auth_file, "w") as f:
                 json.dump(auth_data, f)
-            
+
             # Test: Import and use the auth utilities
-            with patch('pathlib.Path.home', return_value=Path(temp_dir)):
+            with patch("pathlib.Path.home", return_value=Path(temp_dir)):
                 with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
                     from utils.chatgpt_auth import get_valid_chatgpt_auth
-                    
+
                     # Verify auth is loaded correctly
                     auth = get_valid_chatgpt_auth()
                     assert auth is not None
@@ -51,60 +51,60 @@ class TestChatGPTFunctional:
         """Test that provider factory works with ChatGPT tokens."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Setup auth file
-            codex_dir = Path(temp_dir) / ".codex" 
+            codex_dir = Path(temp_dir) / ".codex"
             codex_dir.mkdir()
             auth_file = codex_dir / "auth.json"
-            
+
             auth_data = {
                 "tokens": {
                     "access_token": "test_chatgpt_token",
                     "account_id": "test_account_id",
                     "refresh_token": "test_refresh",
-                    "id_token": "test_id_token"
+                    "id_token": "test_id_token",
                 },
-                "last_refresh": "2025-01-01T00:00:00Z"
+                "last_refresh": "2025-01-01T00:00:00Z",
             }
-            
-            with open(auth_file, 'w') as f:
+
+            with open(auth_file, "w") as f:
                 json.dump(auth_data, f)
-            
+
             # Test provider creation
-            with patch('pathlib.Path.home', return_value=Path(temp_dir)):
+            with patch("pathlib.Path.home", return_value=Path(temp_dir)):
                 with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
                     from providers.openai_provider import OpenAIModelProvider
-                    
+
                     # Create provider with ChatGPT token
                     provider = OpenAIModelProvider("test_chatgpt_token")
-                    
+
                     # Verify ChatGPT-specific configuration
                     assert provider.base_url == "https://chatgpt.com/backend-api/codex/"
-                    assert hasattr(provider, 'DEFAULT_HEADERS')
+                    assert hasattr(provider, "DEFAULT_HEADERS")
                     headers = provider.DEFAULT_HEADERS
-                    assert headers['Authorization'] == 'Bearer test_chatgpt_token'
-                    assert headers['originator'] == 'codex_cli_rs'
-                    assert headers['chatgpt-account-id'] == 'test_account_id'
+                    assert headers["Authorization"] == "Bearer test_chatgpt_token"
+                    assert headers["originator"] == "codex_cli_rs"
+                    assert headers["chatgpt-account-id"] == "test_account_id"
 
     def test_mode_disabled_uses_standard_api(self):
         """Test that standard OpenAI API is used when ChatGPT mode is disabled."""
         with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "false"}):
             from providers.openai_provider import OpenAIModelProvider
-            
+
             provider = OpenAIModelProvider("sk-standard_api_key")
-            
+
             # Verify standard OpenAI configuration
             assert provider.base_url == "https://api.openai.com/v1"
             # Should not have ChatGPT headers
-            if hasattr(provider, 'DEFAULT_HEADERS'):
+            if hasattr(provider, "DEFAULT_HEADERS"):
                 headers = provider.DEFAULT_HEADERS or {}
-                assert 'originator' not in headers
-                assert 'chatgpt-account-id' not in headers
+                assert "originator" not in headers
+                assert "chatgpt-account-id" not in headers
 
     def test_missing_auth_file_fallback(self):
         """Test fallback behavior when auth file is missing."""
-        with patch('pathlib.Path.exists', return_value=False):
+        with patch("pathlib.Path.exists", return_value=False):
             with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
                 from utils.chatgpt_auth import get_valid_chatgpt_auth
-                
+
                 # Should return None when auth file doesn't exist
                 auth = get_valid_chatgpt_auth()
                 assert auth is None
@@ -122,23 +122,23 @@ class TestEdgeCases:
             {"tokens": {}, "last_refresh": "2025-01-01T00:00:00Z"},
             # Missing required fields
             {"tokens": {"access_token": "token"}, "last_refresh": "2025-01-01T00:00:00Z"},
-            # Empty required fields  
+            # Empty required fields
             {"tokens": {"access_token": "", "account_id": "account"}, "last_refresh": "2025-01-01T00:00:00Z"},
         ]
-        
+
         for auth_data in test_cases:
             with tempfile.TemporaryDirectory() as temp_dir:
                 codex_dir = Path(temp_dir) / ".codex"
-                codex_dir.mkdir() 
+                codex_dir.mkdir()
                 auth_file = codex_dir / "auth.json"
-                
-                with open(auth_file, 'w') as f:
+
+                with open(auth_file, "w") as f:
                     json.dump(auth_data, f)
-                
-                with patch('pathlib.Path.home', return_value=Path(temp_dir)):
+
+                with patch("pathlib.Path.home", return_value=Path(temp_dir)):
                     with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
                         from utils.chatgpt_auth import get_valid_chatgpt_auth
-                        
+
                         # Should return None for invalid auth data
                         auth = get_valid_chatgpt_auth()
                         assert auth is None
@@ -146,10 +146,10 @@ class TestEdgeCases:
     def test_environment_variable_variations(self):
         """Test different environment variable values."""
         from utils.chatgpt_auth import is_chatgpt_mode_enabled
-        
+
         test_cases = [
             ("true", True),
-            ("TRUE", True), 
+            ("TRUE", True),
             ("True", True),
             ("false", False),
             ("FALSE", False),
@@ -158,7 +158,7 @@ class TestEdgeCases:
             ("1", False),
             ("yes", False),
         ]
-        
+
         for env_value, expected in test_cases:
             with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": env_value}):
                 assert is_chatgpt_mode_enabled() == expected

--- a/tests/test_chatgpt_functional.py
+++ b/tests/test_chatgpt_functional.py
@@ -1,0 +1,164 @@
+"""Functional tests for ChatGPT authentication integration."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestChatGPTFunctional:
+    """Functional tests for the complete ChatGPT authentication flow."""
+
+    def test_end_to_end_chatgpt_authentication(self):
+        """Test complete ChatGPT authentication flow."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Setup: Create a realistic auth file
+            codex_dir = Path(temp_dir) / ".codex"
+            codex_dir.mkdir()
+            auth_file = codex_dir / "auth.json"
+            
+            # Use realistic auth data structure (based on user's example)
+            auth_data = {
+                "OPENAI_API_KEY": None,
+                "tokens": {
+                    "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImIxZGQzZjhmLTlhYWQtNDdmZS1iMGU3LWVkYjAwOTc3N2Q2YiIsInR5cCI6IkpXVCJ9...",
+                    "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE5MzQ0ZTY1LWJiYzktNDRkMS1hOWQwLWY5NTdiMDc5YmQwZSIsInR5cCI6IkpXVCJ9...",
+                    "refresh_token": "rt_Q5_RJlnifFDOFXQ2UxJYjJRIcDvDHj1wdR2ZVAtvSVc.aaFuBDVHEN-T-O1ndmpzLEqtzTl3xgJmTl8pT4T2e5w",
+                    "account_id": "f213aaef-b15f-4084-a2c9-e5e1b54ba05c"
+                },
+                "last_refresh": "2025-08-08T23:04:28.373728Z"
+            }
+            
+            with open(auth_file, 'w') as f:
+                json.dump(auth_data, f)
+            
+            # Test: Import and use the auth utilities
+            with patch('pathlib.Path.home', return_value=Path(temp_dir)):
+                with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
+                    from utils.chatgpt_auth import get_valid_chatgpt_auth
+                    
+                    # Verify auth is loaded correctly
+                    auth = get_valid_chatgpt_auth()
+                    assert auth is not None
+                    assert auth.access_token.startswith("eyJhbGciOiJSUzI1NiIs")
+                    assert auth.account_id == "f213aaef-b15f-4084-a2c9-e5e1b54ba05c"
+                    assert auth.is_valid()
+
+    def test_provider_factory_integration(self):
+        """Test that provider factory works with ChatGPT tokens."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Setup auth file
+            codex_dir = Path(temp_dir) / ".codex" 
+            codex_dir.mkdir()
+            auth_file = codex_dir / "auth.json"
+            
+            auth_data = {
+                "tokens": {
+                    "access_token": "test_chatgpt_token",
+                    "account_id": "test_account_id",
+                    "refresh_token": "test_refresh",
+                    "id_token": "test_id_token"
+                },
+                "last_refresh": "2025-01-01T00:00:00Z"
+            }
+            
+            with open(auth_file, 'w') as f:
+                json.dump(auth_data, f)
+            
+            # Test provider creation
+            with patch('pathlib.Path.home', return_value=Path(temp_dir)):
+                with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
+                    from providers.openai_provider import OpenAIModelProvider
+                    
+                    # Create provider with ChatGPT token
+                    provider = OpenAIModelProvider("test_chatgpt_token")
+                    
+                    # Verify ChatGPT-specific configuration
+                    assert provider.base_url == "https://chatgpt.com/backend-api/codex/"
+                    assert hasattr(provider, 'DEFAULT_HEADERS')
+                    headers = provider.DEFAULT_HEADERS
+                    assert headers['Authorization'] == 'Bearer test_chatgpt_token'
+                    assert headers['originator'] == 'codex_cli_rs'
+                    assert headers['chatgpt-account-id'] == 'test_account_id'
+
+    def test_mode_disabled_uses_standard_api(self):
+        """Test that standard OpenAI API is used when ChatGPT mode is disabled."""
+        with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "false"}):
+            from providers.openai_provider import OpenAIModelProvider
+            
+            provider = OpenAIModelProvider("sk-standard_api_key")
+            
+            # Verify standard OpenAI configuration
+            assert provider.base_url == "https://api.openai.com/v1"
+            # Should not have ChatGPT headers
+            if hasattr(provider, 'DEFAULT_HEADERS'):
+                headers = provider.DEFAULT_HEADERS or {}
+                assert 'originator' not in headers
+                assert 'chatgpt-account-id' not in headers
+
+    def test_missing_auth_file_fallback(self):
+        """Test fallback behavior when auth file is missing."""
+        with patch('pathlib.Path.exists', return_value=False):
+            with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
+                from utils.chatgpt_auth import get_valid_chatgpt_auth
+                
+                # Should return None when auth file doesn't exist
+                auth = get_valid_chatgpt_auth()
+                assert auth is None
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_malformed_auth_file(self):
+        """Test handling of malformed auth files."""
+        test_cases = [
+            # Missing tokens section
+            {"last_refresh": "2025-01-01T00:00:00Z"},
+            # Empty tokens
+            {"tokens": {}, "last_refresh": "2025-01-01T00:00:00Z"},
+            # Missing required fields
+            {"tokens": {"access_token": "token"}, "last_refresh": "2025-01-01T00:00:00Z"},
+            # Empty required fields  
+            {"tokens": {"access_token": "", "account_id": "account"}, "last_refresh": "2025-01-01T00:00:00Z"},
+        ]
+        
+        for auth_data in test_cases:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                codex_dir = Path(temp_dir) / ".codex"
+                codex_dir.mkdir() 
+                auth_file = codex_dir / "auth.json"
+                
+                with open(auth_file, 'w') as f:
+                    json.dump(auth_data, f)
+                
+                with patch('pathlib.Path.home', return_value=Path(temp_dir)):
+                    with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"}):
+                        from utils.chatgpt_auth import get_valid_chatgpt_auth
+                        
+                        # Should return None for invalid auth data
+                        auth = get_valid_chatgpt_auth()
+                        assert auth is None
+
+    def test_environment_variable_variations(self):
+        """Test different environment variable values."""
+        from utils.chatgpt_auth import is_chatgpt_mode_enabled
+        
+        test_cases = [
+            ("true", True),
+            ("TRUE", True), 
+            ("True", True),
+            ("false", False),
+            ("FALSE", False),
+            ("", False),
+            ("invalid", False),
+            ("1", False),
+            ("yes", False),
+        ]
+        
+        for env_value, expected in test_cases:
+            with patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": env_value}):
+                assert is_chatgpt_mode_enabled() == expected

--- a/tests/test_chatgpt_functional.py
+++ b/tests/test_chatgpt_functional.py
@@ -6,8 +6,6 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 
 class TestChatGPTFunctional:
     """Functional tests for the complete ChatGPT authentication flow."""

--- a/tests/test_chatgpt_integration.py
+++ b/tests/test_chatgpt_integration.py
@@ -1,0 +1,209 @@
+"""Tests for ChatGPT integration in server configuration."""
+
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from utils.chatgpt_auth import ChatGPTAuth
+from providers.openai_provider import OpenAIModelProvider
+
+
+class TestServerChatGPTIntegration:
+    """Test ChatGPT integration in server configuration."""
+
+    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    @patch.dict(os.environ, {"OPENAI_API_KEY": ""}, clear=False)
+    def test_chatgpt_auth_priority(self, mock_get_valid_auth):
+        """Test that ChatGPT auth takes priority over API key."""
+        # Mock valid ChatGPT auth
+        mock_auth = ChatGPTAuth(
+            access_token="chatgpt_token",
+            account_id="chatgpt_account",
+            refresh_token="refresh_token",
+            id_token="id_token",
+            last_refresh="2025-01-01T00:00:00Z"
+        )
+        mock_get_valid_auth.return_value = mock_auth
+        
+        # Import configure_providers to test the logic
+        from server import configure_providers
+        from providers.registry import ModelProviderRegistry
+        
+        # Reset registry
+        ModelProviderRegistry._instance = None
+        
+        # Mock all other API keys to avoid side effects
+        with patch.dict(os.environ, {
+            "GEMINI_API_KEY": "",
+            "XAI_API_KEY": "",
+            "DIAL_API_KEY": "",
+            "OPENROUTER_API_KEY": "",
+            "CUSTOM_API_URL": "",
+            "OPENAI_API_KEY": "fallback_api_key"
+        }):
+            configure_providers()
+            
+            # Verify ChatGPT auth was detected
+            mock_get_valid_auth.assert_called_once()
+
+    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "fallback_key"})
+    def test_api_key_fallback(self, mock_get_valid_auth):
+        """Test fallback to API key when ChatGPT auth not available."""
+        # Mock no ChatGPT auth available
+        mock_get_valid_auth.return_value = None
+        
+        from server import configure_providers
+        from providers.registry import ModelProviderRegistry
+        
+        # Reset registry
+        ModelProviderRegistry._instance = None
+        
+        # Mock all other API keys to avoid side effects
+        with patch.dict(os.environ, {
+            "GEMINI_API_KEY": "",
+            "XAI_API_KEY": "",
+            "DIAL_API_KEY": "",
+            "OPENROUTER_API_KEY": "",
+            "CUSTOM_API_URL": ""
+        }):
+            configure_providers()
+            
+            # Verify ChatGPT auth was checked but fallback used
+            mock_get_valid_auth.assert_called_once()
+
+
+class TestOpenAIProviderChatGPT:
+    """Test OpenAI provider ChatGPT integration."""
+
+    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    def test_chatgpt_provider_initialization(self, mock_get_valid_auth):
+        """Test OpenAI provider initialization with ChatGPT auth."""
+        # Mock valid ChatGPT auth
+        mock_auth = ChatGPTAuth(
+            access_token="chatgpt_access_token",
+            account_id="chatgpt_account_id",
+            refresh_token="refresh_token",
+            id_token="id_token",
+            last_refresh="2025-01-01T00:00:00Z"
+        )
+        mock_get_valid_auth.return_value = mock_auth
+        
+        # Create provider with ChatGPT token
+        provider = OpenAIModelProvider("chatgpt_access_token")
+        
+        # Verify ChatGPT-specific configuration
+        assert provider.base_url == "https://chatgpt.com/backend-api/codex/"
+        assert hasattr(provider, 'DEFAULT_HEADERS')
+        assert provider.DEFAULT_HEADERS['Authorization'] == 'Bearer chatgpt_access_token'
+        assert provider.DEFAULT_HEADERS['originator'] == 'codex_cli_rs'
+        assert provider.DEFAULT_HEADERS['chatgpt-account-id'] == 'chatgpt_account_id'
+
+    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    def test_standard_openai_provider_initialization(self, mock_get_valid_auth):
+        """Test standard OpenAI provider initialization."""
+        # Mock no ChatGPT auth
+        mock_get_valid_auth.return_value = None
+        
+        # Create provider with standard API key
+        provider = OpenAIModelProvider("sk-standard_api_key")
+        
+        # Verify standard OpenAI configuration
+        assert provider.base_url == "https://api.openai.com/v1"
+        assert not hasattr(provider, 'DEFAULT_HEADERS') or not provider.DEFAULT_HEADERS
+
+    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    def test_different_api_key_no_chatgpt_config(self, mock_get_valid_auth):
+        """Test that ChatGPT config is not used with different API key."""
+        # Mock valid ChatGPT auth but use different API key
+        mock_auth = ChatGPTAuth(
+            access_token="chatgpt_access_token",
+            account_id="chatgpt_account_id",
+            refresh_token="refresh_token",
+            id_token="id_token",
+            last_refresh="2025-01-01T00:00:00Z"
+        )
+        mock_get_valid_auth.return_value = mock_auth
+        
+        # Create provider with different API key
+        provider = OpenAIModelProvider("sk-different_api_key")
+        
+        # Verify standard OpenAI configuration is used
+        assert provider.base_url == "https://api.openai.com/v1"
+        assert not hasattr(provider, 'DEFAULT_HEADERS') or not provider.DEFAULT_HEADERS
+
+
+class TestEnvironmentVariableHandling:
+    """Test environment variable handling for ChatGPT mode."""
+
+    @patch('utils.chatgpt_auth.get_chatgpt_auth')
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
+    def test_chatgpt_mode_enabled_with_valid_auth(self, mock_get_auth):
+        """Test behavior when ChatGPT mode is enabled with valid auth."""
+        from utils.chatgpt_auth import get_valid_chatgpt_auth
+        
+        # Mock valid auth data
+        mock_auth = ChatGPTAuth(
+            access_token="valid_token",
+            account_id="valid_account",
+            refresh_token="refresh_token",
+            id_token="id_token", 
+            last_refresh="2025-01-01T00:00:00Z"
+        )
+        mock_get_auth.return_value = mock_auth
+        
+        result = get_valid_chatgpt_auth()
+        assert result is not None
+        assert result.access_token == "valid_token"
+
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "false"})
+    def test_chatgpt_mode_disabled(self):
+        """Test behavior when ChatGPT mode is disabled."""
+        from utils.chatgpt_auth import get_valid_chatgpt_auth
+        
+        result = get_valid_chatgpt_auth()
+        assert result is None
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_chatgpt_mode_not_set(self):
+        """Test behavior when ChatGPT mode environment variable is not set."""
+        from utils.chatgpt_auth import get_valid_chatgpt_auth
+        
+        result = get_valid_chatgpt_auth()
+        assert result is None
+
+
+class TestErrorHandling:
+    """Test error handling in ChatGPT integration."""
+
+    @patch('utils.chatgpt_auth.get_chatgpt_auth')
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
+    def test_invalid_chatgpt_auth_handling(self, mock_get_auth):
+        """Test handling of invalid ChatGPT auth data."""
+        from utils.chatgpt_auth import get_valid_chatgpt_auth
+        
+        # Mock invalid auth (missing access token)
+        mock_auth = ChatGPTAuth(
+            access_token="",  # Empty access token
+            account_id="account_id",
+            refresh_token="refresh_token",
+            id_token="id_token",
+            last_refresh="2025-01-01T00:00:00Z"
+        )
+        mock_get_auth.return_value = mock_auth
+        
+        result = get_valid_chatgpt_auth()
+        assert result is None
+
+    @patch('utils.chatgpt_auth.get_chatgpt_auth')
+    @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
+    def test_auth_file_read_error_handling(self, mock_get_auth):
+        """Test handling of auth file read errors."""
+        from utils.chatgpt_auth import get_valid_chatgpt_auth
+        
+        # Mock auth file read error
+        mock_get_auth.return_value = None
+        
+        result = get_valid_chatgpt_auth()
+        assert result is None

--- a/tests/test_chatgpt_integration.py
+++ b/tests/test_chatgpt_integration.py
@@ -12,7 +12,7 @@ from providers.openai_provider import OpenAIModelProvider
 class TestServerChatGPTIntegration:
     """Test ChatGPT integration in server configuration."""
 
-    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    @patch("utils.chatgpt_auth.get_valid_chatgpt_auth")
     @patch.dict(os.environ, {"OPENAI_API_KEY": ""}, clear=False)
     def test_chatgpt_auth_priority(self, mock_get_valid_auth):
         """Test that ChatGPT auth takes priority over API key."""
@@ -22,54 +22,60 @@ class TestServerChatGPTIntegration:
             account_id="chatgpt_account",
             refresh_token="refresh_token",
             id_token="id_token",
-            last_refresh="2025-01-01T00:00:00Z"
+            last_refresh="2025-01-01T00:00:00Z",
         )
         mock_get_valid_auth.return_value = mock_auth
-        
+
         # Import configure_providers to test the logic
         from server import configure_providers
         from providers.registry import ModelProviderRegistry
-        
+
         # Reset registry
         ModelProviderRegistry._instance = None
-        
+
         # Mock all other API keys to avoid side effects
-        with patch.dict(os.environ, {
-            "GEMINI_API_KEY": "",
-            "XAI_API_KEY": "",
-            "DIAL_API_KEY": "",
-            "OPENROUTER_API_KEY": "",
-            "CUSTOM_API_URL": "",
-            "OPENAI_API_KEY": "fallback_api_key"
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "GEMINI_API_KEY": "",
+                "XAI_API_KEY": "",
+                "DIAL_API_KEY": "",
+                "OPENROUTER_API_KEY": "",
+                "CUSTOM_API_URL": "",
+                "OPENAI_API_KEY": "fallback_api_key",
+            },
+        ):
             configure_providers()
-            
+
             # Verify ChatGPT auth was detected
             mock_get_valid_auth.assert_called_once()
 
-    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    @patch("utils.chatgpt_auth.get_valid_chatgpt_auth")
     @patch.dict(os.environ, {"OPENAI_API_KEY": "fallback_key"})
     def test_api_key_fallback(self, mock_get_valid_auth):
         """Test fallback to API key when ChatGPT auth not available."""
         # Mock no ChatGPT auth available
         mock_get_valid_auth.return_value = None
-        
+
         from server import configure_providers
         from providers.registry import ModelProviderRegistry
-        
+
         # Reset registry
         ModelProviderRegistry._instance = None
-        
+
         # Mock all other API keys to avoid side effects
-        with patch.dict(os.environ, {
-            "GEMINI_API_KEY": "",
-            "XAI_API_KEY": "",
-            "DIAL_API_KEY": "",
-            "OPENROUTER_API_KEY": "",
-            "CUSTOM_API_URL": ""
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "GEMINI_API_KEY": "",
+                "XAI_API_KEY": "",
+                "DIAL_API_KEY": "",
+                "OPENROUTER_API_KEY": "",
+                "CUSTOM_API_URL": "",
+            },
+        ):
             configure_providers()
-            
+
             # Verify ChatGPT auth was checked but fallback used
             mock_get_valid_auth.assert_called_once()
 
@@ -77,7 +83,7 @@ class TestServerChatGPTIntegration:
 class TestOpenAIProviderChatGPT:
     """Test OpenAI provider ChatGPT integration."""
 
-    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    @patch("utils.chatgpt_auth.get_valid_chatgpt_auth")
     def test_chatgpt_provider_initialization(self, mock_get_valid_auth):
         """Test OpenAI provider initialization with ChatGPT auth."""
         # Mock valid ChatGPT auth
@@ -86,34 +92,34 @@ class TestOpenAIProviderChatGPT:
             account_id="chatgpt_account_id",
             refresh_token="refresh_token",
             id_token="id_token",
-            last_refresh="2025-01-01T00:00:00Z"
+            last_refresh="2025-01-01T00:00:00Z",
         )
         mock_get_valid_auth.return_value = mock_auth
-        
+
         # Create provider with ChatGPT token
         provider = OpenAIModelProvider("chatgpt_access_token")
-        
+
         # Verify ChatGPT-specific configuration
         assert provider.base_url == "https://chatgpt.com/backend-api/codex/"
-        assert hasattr(provider, 'DEFAULT_HEADERS')
-        assert provider.DEFAULT_HEADERS['Authorization'] == 'Bearer chatgpt_access_token'
-        assert provider.DEFAULT_HEADERS['originator'] == 'codex_cli_rs'
-        assert provider.DEFAULT_HEADERS['chatgpt-account-id'] == 'chatgpt_account_id'
+        assert hasattr(provider, "DEFAULT_HEADERS")
+        assert provider.DEFAULT_HEADERS["Authorization"] == "Bearer chatgpt_access_token"
+        assert provider.DEFAULT_HEADERS["originator"] == "codex_cli_rs"
+        assert provider.DEFAULT_HEADERS["chatgpt-account-id"] == "chatgpt_account_id"
 
-    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    @patch("utils.chatgpt_auth.get_valid_chatgpt_auth")
     def test_standard_openai_provider_initialization(self, mock_get_valid_auth):
         """Test standard OpenAI provider initialization."""
         # Mock no ChatGPT auth
         mock_get_valid_auth.return_value = None
-        
+
         # Create provider with standard API key
         provider = OpenAIModelProvider("sk-standard_api_key")
-        
+
         # Verify standard OpenAI configuration
         assert provider.base_url == "https://api.openai.com/v1"
-        assert not hasattr(provider, 'DEFAULT_HEADERS') or not provider.DEFAULT_HEADERS
+        assert not hasattr(provider, "DEFAULT_HEADERS") or not provider.DEFAULT_HEADERS
 
-    @patch('utils.chatgpt_auth.get_valid_chatgpt_auth')
+    @patch("utils.chatgpt_auth.get_valid_chatgpt_auth")
     def test_different_api_key_no_chatgpt_config(self, mock_get_valid_auth):
         """Test that ChatGPT config is not used with different API key."""
         # Mock valid ChatGPT auth but use different API key
@@ -122,37 +128,37 @@ class TestOpenAIProviderChatGPT:
             account_id="chatgpt_account_id",
             refresh_token="refresh_token",
             id_token="id_token",
-            last_refresh="2025-01-01T00:00:00Z"
+            last_refresh="2025-01-01T00:00:00Z",
         )
         mock_get_valid_auth.return_value = mock_auth
-        
+
         # Create provider with different API key
         provider = OpenAIModelProvider("sk-different_api_key")
-        
+
         # Verify standard OpenAI configuration is used
         assert provider.base_url == "https://api.openai.com/v1"
-        assert not hasattr(provider, 'DEFAULT_HEADERS') or not provider.DEFAULT_HEADERS
+        assert not hasattr(provider, "DEFAULT_HEADERS") or not provider.DEFAULT_HEADERS
 
 
 class TestEnvironmentVariableHandling:
     """Test environment variable handling for ChatGPT mode."""
 
-    @patch('utils.chatgpt_auth.get_chatgpt_auth')
+    @patch("utils.chatgpt_auth.get_chatgpt_auth")
     @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
     def test_chatgpt_mode_enabled_with_valid_auth(self, mock_get_auth):
         """Test behavior when ChatGPT mode is enabled with valid auth."""
         from utils.chatgpt_auth import get_valid_chatgpt_auth
-        
+
         # Mock valid auth data
         mock_auth = ChatGPTAuth(
             access_token="valid_token",
             account_id="valid_account",
             refresh_token="refresh_token",
-            id_token="id_token", 
-            last_refresh="2025-01-01T00:00:00Z"
+            id_token="id_token",
+            last_refresh="2025-01-01T00:00:00Z",
         )
         mock_get_auth.return_value = mock_auth
-        
+
         result = get_valid_chatgpt_auth()
         assert result is not None
         assert result.access_token == "valid_token"
@@ -161,7 +167,7 @@ class TestEnvironmentVariableHandling:
     def test_chatgpt_mode_disabled(self):
         """Test behavior when ChatGPT mode is disabled."""
         from utils.chatgpt_auth import get_valid_chatgpt_auth
-        
+
         result = get_valid_chatgpt_auth()
         assert result is None
 
@@ -169,7 +175,7 @@ class TestEnvironmentVariableHandling:
     def test_chatgpt_mode_not_set(self):
         """Test behavior when ChatGPT mode environment variable is not set."""
         from utils.chatgpt_auth import get_valid_chatgpt_auth
-        
+
         result = get_valid_chatgpt_auth()
         assert result is None
 
@@ -177,33 +183,33 @@ class TestEnvironmentVariableHandling:
 class TestErrorHandling:
     """Test error handling in ChatGPT integration."""
 
-    @patch('utils.chatgpt_auth.get_chatgpt_auth')
+    @patch("utils.chatgpt_auth.get_chatgpt_auth")
     @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
     def test_invalid_chatgpt_auth_handling(self, mock_get_auth):
         """Test handling of invalid ChatGPT auth data."""
         from utils.chatgpt_auth import get_valid_chatgpt_auth
-        
+
         # Mock invalid auth (missing access token)
         mock_auth = ChatGPTAuth(
             access_token="",  # Empty access token
             account_id="account_id",
             refresh_token="refresh_token",
             id_token="id_token",
-            last_refresh="2025-01-01T00:00:00Z"
+            last_refresh="2025-01-01T00:00:00Z",
         )
         mock_get_auth.return_value = mock_auth
-        
+
         result = get_valid_chatgpt_auth()
         assert result is None
 
-    @patch('utils.chatgpt_auth.get_chatgpt_auth')
+    @patch("utils.chatgpt_auth.get_chatgpt_auth")
     @patch.dict(os.environ, {"OPENAI_CHATGPT_LOGIN_MODE": "true"})
     def test_auth_file_read_error_handling(self, mock_get_auth):
         """Test handling of auth file read errors."""
         from utils.chatgpt_auth import get_valid_chatgpt_auth
-        
+
         # Mock auth file read error
         mock_get_auth.return_value = None
-        
+
         result = get_valid_chatgpt_auth()
         assert result is None

--- a/tests/test_chatgpt_integration.py
+++ b/tests/test_chatgpt_integration.py
@@ -1,12 +1,10 @@
 """Tests for ChatGPT integration in server configuration."""
 
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
-
-from utils.chatgpt_auth import ChatGPTAuth
 from providers.openai_provider import OpenAIModelProvider
+from utils.chatgpt_auth import ChatGPTAuth
 
 
 class TestServerChatGPTIntegration:
@@ -27,8 +25,8 @@ class TestServerChatGPTIntegration:
         mock_get_valid_auth.return_value = mock_auth
 
         # Import configure_providers to test the logic
-        from server import configure_providers
         from providers.registry import ModelProviderRegistry
+        from server import configure_providers
 
         # Reset registry
         ModelProviderRegistry._instance = None
@@ -57,8 +55,8 @@ class TestServerChatGPTIntegration:
         # Mock no ChatGPT auth available
         mock_get_valid_auth.return_value = None
 
-        from server import configure_providers
         from providers.registry import ModelProviderRegistry
+        from server import configure_providers
 
         # Reset registry
         ModelProviderRegistry._instance = None

--- a/utils/chatgpt_auth.py
+++ b/utils/chatgpt_auth.py
@@ -2,8 +2,8 @@
 
 import json
 import os
-from pathlib import Path
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 
@@ -29,7 +29,7 @@ def get_chatgpt_auth() -> Optional[ChatGPTAuth]:
         if not auth_file.exists():
             return None
 
-        with open(auth_file, "r") as f:
+        with open(auth_file) as f:
             data = json.load(f)
 
         tokens = data.get("tokens", {})

--- a/utils/chatgpt_auth.py
+++ b/utils/chatgpt_auth.py
@@ -1,0 +1,57 @@
+"""Simple ChatGPT authentication utility."""
+
+import json
+import os
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ChatGPTAuth:
+    """ChatGPT authentication data."""
+    access_token: str
+    account_id: str
+    refresh_token: str
+    id_token: str
+    last_refresh: str
+    
+    def is_valid(self) -> bool:
+        """Check if auth has required tokens."""
+        return bool(self.access_token and self.account_id)
+
+
+def get_chatgpt_auth() -> Optional[ChatGPTAuth]:
+    """Get auth data from ~/.codex/auth.json if available."""
+    try:
+        auth_file = Path.home() / ".codex" / "auth.json"
+        if not auth_file.exists():
+            return None
+        
+        with open(auth_file, 'r') as f:
+            data = json.load(f)
+        
+        tokens = data.get("tokens", {})
+        return ChatGPTAuth(
+            access_token=tokens.get("access_token", ""),
+            account_id=tokens.get("account_id", ""),
+            refresh_token=tokens.get("refresh_token", ""),
+            id_token=tokens.get("id_token", ""),
+            last_refresh=data.get("last_refresh", "")
+        )
+    except Exception:
+        return None
+
+
+def is_chatgpt_mode_enabled() -> bool:
+    """Check if OPENAI_CHATGPT_LOGIN_MODE=true."""
+    return os.getenv("OPENAI_CHATGPT_LOGIN_MODE", "").lower() == "true"
+
+
+def get_valid_chatgpt_auth() -> Optional[ChatGPTAuth]:
+    """Get valid ChatGPT auth if mode is enabled and tokens exist."""
+    if not is_chatgpt_mode_enabled():
+        return None
+    
+    auth = get_chatgpt_auth()
+    return auth if auth and auth.is_valid() else None

--- a/utils/chatgpt_auth.py
+++ b/utils/chatgpt_auth.py
@@ -10,12 +10,13 @@ from typing import Optional
 @dataclass
 class ChatGPTAuth:
     """ChatGPT authentication data."""
+
     access_token: str
     account_id: str
     refresh_token: str
     id_token: str
     last_refresh: str
-    
+
     def is_valid(self) -> bool:
         """Check if auth has required tokens."""
         return bool(self.access_token and self.account_id)
@@ -27,17 +28,17 @@ def get_chatgpt_auth() -> Optional[ChatGPTAuth]:
         auth_file = Path.home() / ".codex" / "auth.json"
         if not auth_file.exists():
             return None
-        
-        with open(auth_file, 'r') as f:
+
+        with open(auth_file, "r") as f:
             data = json.load(f)
-        
+
         tokens = data.get("tokens", {})
         return ChatGPTAuth(
             access_token=tokens.get("access_token", ""),
             account_id=tokens.get("account_id", ""),
             refresh_token=tokens.get("refresh_token", ""),
             id_token=tokens.get("id_token", ""),
-            last_refresh=data.get("last_refresh", "")
+            last_refresh=data.get("last_refresh", ""),
         )
     except Exception:
         return None
@@ -52,6 +53,6 @@ def get_valid_chatgpt_auth() -> Optional[ChatGPTAuth]:
     """Get valid ChatGPT auth if mode is enabled and tokens exist."""
     if not is_chatgpt_mode_enabled():
         return None
-    
+
     auth = get_chatgpt_auth()
     return auth if auth and auth.is_valid() else None


### PR DESCRIPTION
Add support for using ChatGPT Pro subscription tokens as an alternative to OpenAI API keys. When OPENAI_CHATGPT_LOGIN_MODE=true, the server prioritizes tokens from ~/.codex/auth.json over OPENAI_API_KEY.

  Features:
  - Priority authentication: ChatGPT tokens > API key > disabled
  - ChatGPT backend API integration with required headers
  - Comprehensive test coverage (34 tests)
  - Fallback to standard API when mode disabled or tokens unavailable
  - Documentation updates in README and .env.example

  This allows ChatGPT Pro users to leverage their existing subscription instead of purchasing separate OpenAI API credits.

  Changes Made

  - Added utils/chatgpt_auth.py with ChatGPT authentication utilities
  - Updated server.py configure_providers() with priority authentication logic
  - Modified providers/openai_provider.py to support ChatGPT backend API
  - Added comprehensive test suite (34 tests) covering unit, integration, and functional scenarios
  - Updated .env.example with detailed ChatGPT mode documentation
  - Updated README.md with feature descriptions and setup instructions
  - No breaking changes - fully backward compatible
  - No new dependencies added

  Testing

  Please review our ../docs/testing.md before submitting.

  Run all linting and tests (required):

  # Activate virtual environment first
  source venv/bin/activate

  # Run comprehensive code quality checks (recommended)
  ./code_quality_checks.sh

  # If you made tool changes, also run simulator tests
  python communication_simulator_test.py

  - All linting passes (ruff, black, isort)
  - All unit tests pass
  - For new features: Unit tests added in tests/
    - tests/test_chatgpt_auth.py - Unit tests for authentication utilities
    - tests/test_chatgpt_integration.py - Integration tests for server configuration
    - tests/test_chatgpt_functional.py - End-to-end functional tests
  - For tool changes: Simulator tests added in simulator_tests/ (N/A - core auth feature)
  - For bug fixes: Tests added to prevent regression (N/A - new feature)
  - Simulator tests pass (N/A - auth feature doesn't affect tool behavior)
  - Manual testing completed with realistic scenarios

  Related Issues

[  Implements user-requested ChatGPT Pro subscription token authentication support.
](https://github.com/BeehiveInnovations/zen-mcp-server/issues/225)
  Checklist

  - PR title follows the format guidelines above
  - Activated venv and ran code quality checks: source venv/bin/activate && ./code_quality_checks.sh
  - Self-review completed
  - Tests added for ALL changes (see Testing section above)
  - Documentation updated as needed
  - All unit tests passing
  - Relevant simulator tests passing (if tool changes)
  - Ready for review

  Additional Notes

  - Feature is fully backward compatible - existing OpenAI API key usage unchanged
  - Comprehensive error handling for missing/invalid auth files
  - Environment variable validation with case-insensitive support
  - ChatGPT mode requires valid tokens in ~/.codex/auth.json with specific structure
  - Falls back gracefully to standard OpenAI API when ChatGPT mode disabled or tokens unavailable
  - All 34 tests pass, covering edge cases and error conditions
