### PR TITLE
feat: add custom Gemini endpoint support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@
 # Option 1: Use native APIs (recommended for direct access)
 # Get your Gemini API key from: https://makersuite.google.com/app/apikey
 GEMINI_API_KEY=your_gemini_api_key_here
+# GEMINI_BASE_URL=                            # Optional: Custom Gemini endpoint (defaults to Google's API)
 
 # Get your OpenAI API key from: https://platform.openai.com/api-keys
 OPENAI_API_KEY=your_openai_api_key_here

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -121,7 +121,7 @@ class GeminiModelProvider(ModelProvider):
         super().__init__(api_key, **kwargs)
         self._client = None
         self._token_counters = {}  # Cache for token counting
-        self._base_url = kwargs.get('base_url', None)  # Optional custom endpoint
+        self._base_url = kwargs.get("base_url", None)  # Optional custom endpoint
 
     @property
     def client(self):

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -130,8 +130,7 @@ class GeminiModelProvider(ModelProvider):
             # Check if custom base URL is provided
             if self._base_url:
                 # Use HttpOptions to set custom endpoint
-                from google.genai.types import HttpOptions
-                http_options = HttpOptions(baseUrl=self._base_url)
+                http_options = types.HttpOptions(baseUrl=self._base_url)
                 logger.debug(f"Initializing Gemini client with custom endpoint: {self._base_url}")
                 self._client = genai.Client(api_key=self.api_key, http_options=http_options)
             else:

--- a/providers/gemini.py
+++ b/providers/gemini.py
@@ -117,16 +117,26 @@ class GeminiModelProvider(ModelProvider):
     }
 
     def __init__(self, api_key: str, **kwargs):
-        """Initialize Gemini provider with API key."""
+        """Initialize Gemini provider with API key and optional base URL."""
         super().__init__(api_key, **kwargs)
         self._client = None
         self._token_counters = {}  # Cache for token counting
+        self._base_url = kwargs.get('base_url', None)  # Optional custom endpoint
 
     @property
     def client(self):
         """Lazy initialization of Gemini client."""
         if self._client is None:
-            self._client = genai.Client(api_key=self.api_key)
+            # Check if custom base URL is provided
+            if self._base_url:
+                # Use HttpOptions to set custom endpoint
+                from google.genai.types import HttpOptions
+                http_options = HttpOptions(baseUrl=self._base_url)
+                logger.debug(f"Initializing Gemini client with custom endpoint: {self._base_url}")
+                self._client = genai.Client(api_key=self.api_key, http_options=http_options)
+            else:
+                # Use default Google endpoint
+                self._client = genai.Client(api_key=self.api_key)
         return self._client
 
     def get_capabilities(self, model_name: str) -> ModelCapabilities:

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -98,13 +98,11 @@ class ModelProviderRegistry:
             if not api_key:
                 return None
             gemini_base_url = os.getenv("GEMINI_BASE_URL")
+            provider_kwargs = {"api_key": api_key}
             if gemini_base_url:
-                # Initialize with custom endpoint
-                provider = provider_class(api_key=api_key, base_url=gemini_base_url)
+                provider_kwargs["base_url"] = gemini_base_url
                 logging.info(f"Initialized Gemini provider with custom endpoint: {gemini_base_url}")
-            else:
-                # Use default Google endpoint
-                provider = provider_class(api_key=api_key)
+            provider = provider_class(**provider_kwargs)
         else:
             if not api_key:
                 return None

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -93,6 +93,18 @@ class ModelProviderRegistry:
                 api_key = api_key or ""
                 # Initialize custom provider with both API key and base URL
                 provider = provider_class(api_key=api_key, base_url=custom_url)
+        elif provider_type == ProviderType.GOOGLE:
+            # For Gemini, check if custom base URL is configured
+            if not api_key:
+                return None
+            gemini_base_url = os.getenv("GEMINI_BASE_URL")
+            if gemini_base_url:
+                # Initialize with custom endpoint
+                provider = provider_class(api_key=api_key, base_url=gemini_base_url)
+                logging.info(f"Initialized Gemini provider with custom endpoint: {gemini_base_url}")
+            else:
+                # Use default Google endpoint
+                provider = provider_class(api_key=api_key)
         else:
             if not api_key:
                 return None


### PR DESCRIPTION
## Summary
  - Adds support for custom Gemini API endpoints via environment configuration
  - Enables use of Gemini-compatible APIs or proxy servers
  - Maintains full backward compatibility with default Google endpoint
  - Transparent to users - no configuration required for standard usage

  ## Changes Made
  - [x] Modified `providers/gemini.py` to accept optional `base_url` parameter and use `HttpOptions`
  - [x] Updated `providers/registry.py` to check `GEMINI_BASE_URL` env variable and pass to provider
  - [x] Added `GEMINI_BASE_URL` configuration option in `.env.example`
  - [x] No breaking changes - fully backward compatible

  ## Benefits
  - **Flexibility**: Support for Gemini-compatible APIs and proxy servers
  - **Enterprise Ready**: Allows use of corporate proxy endpoints
  - **Regional Compliance**: Enable use of regional endpoints
  - **Zero Configuration**: Works out of the box without any setup

  ## Testing
  - [x] Tested with default Google endpoint (no configuration)
  - [x] Tested with custom endpoint configuration
  - [x] Verified backward compatibility
  - [x] All changes are non-breaking

  ## Related Issues
  N/A - New feature addition

  ## Checklist
  - [x] PR title follows Conventional Commits format (`feat:`)
  - [x] Self-review completed
  - [x] Documentation updated (`.env.example`)
  - [x] Backward compatibility maintained
  - [x] Ready for review

  ## Additional Notes
  This feature allows users to configure custom Gemini endpoints for scenarios such as:
  - Using Gemini through corporate proxies
  - Connecting to Gemini-compatible APIs
  - Regional endpoint requirements for data compliance
