### PR TITLE
feat: add automated stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    # Run daily at 1:30 AM UTC
+    - cron: '30 1 * * *'
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          
+          stale-issue-message: |
+            This issue is stale because it has been open 30 days with no activity. 
+            Remove the stale label or comment or this will be closed in 7 days.
+          stale-pr-message: |
+            This PR is stale because it has been open 30 days with no activity. 
+            Remove the stale label or comment or this will be closed in 7 days.
+          
+          close-issue-message: |
+            This issue was closed because it has been stalled for 7 days with no activity.
+          close-pr-message: |
+            This PR was closed because it has been stalled for 7 days with no activity.
+          
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          
+          exempt-issue-labels: 'pinned,security,enhancement'
+          exempt-pr-labels: 'pinned,security,work-in-progress,draft'
+          
+          operations-per-run: 100


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically manage stale issues and PRs
- Auto-marks issues/PRs as stale after 30 days of inactivity
- Auto-closes stale items after 7 additional days
- Exempts pinned, security, enhancement, and work-in-progress items
- Runs daily at 1:30 AM UTC with manual trigger option

## Benefits
- Keeps issue tracker clean and manageable
- Reduces maintainer burden for old inactive issues
- Provides clear communication to users about stale items
- Respects important issues with exempt labels

## Configuration
- 30 days before marking stale
- 7 days before closing after stale
- API rate limiting protection (100 operations per run)
- Customizable messages for users