### PR TITLE
fix: resolve executable path for clink cross-platform compatibility in CLI

### DIFF
--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import shlex
+import shutil
 import tempfile
 import time
 from collections.abc import Sequence
@@ -65,6 +66,17 @@ class BaseCLIAgent:
         # The runner simply executes the configured CLI command for the selected role.
         command = self._build_command(role=role)
         env = self._build_environment()
+
+        # Resolve executable path for cross-platform compatibility (especially Windows)
+        executable_name = command[0]
+        resolved_executable = shutil.which(executable_name)
+        if resolved_executable is None:
+            raise CLIAgentError(
+                f"Executable '{executable_name}' not found in PATH for CLI '{self.client.name}'. "
+                f"Ensure the command is installed and accessible."
+            )
+        command[0] = resolved_executable
+
         sanitized_command = list(command)
 
         cwd = str(self.client.working_dir) if self.client.working_dir else None

--- a/tests/test_clink_codex_agent.py
+++ b/tests/test_clink_codex_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import shutil
 from pathlib import Path
 
 import pytest
@@ -41,7 +42,11 @@ async def _run_agent_with_process(monkeypatch, agent, role, process):
     async def fake_create_subprocess_exec(*_args, **_kwargs):
         return process
 
+    def fake_which(executable_name):
+        return f"/usr/bin/{executable_name}"
+
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(shutil, "which", fake_which)
     return await agent.run(role=role, prompt="do something", files=[], images=[])
 
 

--- a/tests/test_clink_gemini_agent.py
+++ b/tests/test_clink_gemini_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import shutil
 from pathlib import Path
 
 import pytest
@@ -41,7 +42,11 @@ async def _run_agent_with_process(monkeypatch, agent, role, process):
     async def fake_create_subprocess_exec(*_args, **_kwargs):
         return process
 
+    def fake_which(executable_name):
+        return f"/usr/bin/{executable_name}"
+
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(shutil, "which", fake_which)
     return await agent.run(role=role, prompt="do something", files=[], images=[])
 
 


### PR DESCRIPTION
# PR: Fix executable path resolution for cross-platform compatibility in CLI agent

**Title:** `fix: resolve executable path for cross-platform compatibility in CLI agent`

## Description

Fixes executable resolution for the clink CLI agent on Windows systems. Previously, the agent failed to execute external CLI tools (like `gemini.CMD`) because it didn't properly resolve executable paths with extensions on Windows. This PR uses `shutil.which()` to resolve the full executable path before spawning subprocesses, ensuring cross-platform compatibility.

## Changes Made

- ✅ Modified `clink/agents/base.py:70-78` to use `shutil.which()` for executable path resolution
- ✅ Added proper error handling when executable is not found in PATH
- ✅ Improved error message to guide users when CLI tools are not installed
- ✅ No breaking changes
- ✅ No dependencies added/removed

## Testing

✅ All linting passes (ruff, black, isort)
✅ All unit tests pass
✅ Manual testing completed:
  - Verified `gemini` CLI works through clink on Windows
  - Confirmed executable resolution works for `.CMD`, `.exe`, and standard executables
  - Tested with OAuth-based authentication (cached credentials)

## Related Issues

Fixes #276

## Checklist

- [x] PR title follows the format guidelines above
- [x] Activated venv and ran code quality checks
- [x] Self-review completed
- [x] Tests passing (existing test coverage validates the fix)
- [x] Documentation updated as needed (no doc changes required for internal fix)
- [x] All unit tests passing
- [x] Manual testing completed with realistic scenarios
- [x] Ready for review

## Additional Notes

This fix specifically addresses Windows compatibility where CLI executables may have extensions like `.CMD`, `.exe`, or `.bat`. The `shutil.which()` function handles OS-specific executable resolution automatically, making the clink agent properly cross-platform.

**Testing performed:**
- Verified `clink(cli_name: "gemini", prompt: "hi")` works correctly on Windows with OAuth authentication
- Confirmed the fix resolves the `FileNotFoundError` that occurred when Windows couldn't find `gemini` vs `gemini.CMD`
