### PR TITLE
fix: Add JSON output flag to gemini CLI configuration

### DIFF
--- a/conf/cli_clients/gemini.json
+++ b/conf/cli_clients/gemini.json
@@ -4,7 +4,9 @@
   "additional_args": [
     "--telemetry",
     "false",
-    "--yolo"
+    "--yolo",
+    "-o",
+    "json"
   ],
   "env": {},
   "roles": {


### PR DESCRIPTION
The gemini CLI was returning plain text instead of JSON, causing clink to fail with: 'Failed to decode Gemini CLI JSON output: Expecting value: line 1 column 1 (char 0)'

Root cause: gemini.json was missing the '-o json' flag in additional_args.

This fix adds '-o json' to ensure JSON output format, aligning with the codex pattern (which uses --json).

Tested with gemini CLI v0.8.2
