### PR TITLE
fix: Update Claude CLI commands to new mcp syntax

### DIFF
--- a/run-server.ps1
+++ b/run-server.ps1
@@ -1489,18 +1489,18 @@ function Test-ClaudeCliIntegration {
     Write-Info "Claude CLI detected - checking configuration..."
     
     try {
-        $claudeConfig = claude config list 2>$null
+        $claudeConfig = claude mcp list 2>$null
         if ($claudeConfig -match "zen") {
             Write-Success "Claude CLI already configured for zen server"
         }
         else {
             Write-Info "To add zen server to Claude CLI, run:"
-            Write-Host "  claude config add-server zen $PythonPath $ServerPath" -ForegroundColor Cyan
+            Write-Host "  claude mcp add -s user zen $PythonPath $ServerPath" -ForegroundColor Cyan
         }
     }
     catch {
         Write-Info "To configure Claude CLI manually, run:"
-        Write-Host "  claude config add-server zen $PythonPath $ServerPath" -ForegroundColor Cyan
+        Write-Host "  claude mcp add -s user zen $PythonPath $ServerPath" -ForegroundColor Cyan
     }
 }
 


### PR DESCRIPTION
## Description

Updates PowerShell setup script to use the new Claude CLI command syntax. The Claude CLI recently changed from `claude config` commands to `claude mcp` commands.

## Changes Made

- Updated `Test-ClaudeCliIntegration` to use `claude mcp list` instead of `claude config list`
- Updated configuration instructions to use `claude mcp add -s user` instead of `claude config add-server`

## Testing

- [x] All linting passes (ruff, black, isort)
- [x] All unit tests pass
- [x] Manual testing completed - verified new commands work with current Claude CLI
- [x] Self-review completed

## Related Issues

Fixes configuration detection for Windows users with updated Claude CLI.