### PR TITLE
fix: remove duplicate -o json flag in gemini CLI config

### DIFF
--- a/conf/cli_clients/gemini.json
+++ b/conf/cli_clients/gemini.json
@@ -4,9 +4,7 @@
   "additional_args": [
     "--telemetry",
     "false",
-    "--yolo",
-    "-o",
-    "json"
+    "--yolo"
   ],
   "env": {},
   "roles": {


### PR DESCRIPTION
## Description

Fixes #291 - Removes duplicate `-o json` flag that causes Gemini CLI to return plain text instead of JSON.

## Root Cause

The gemini CLI configuration had a duplicate `-o json` flag:

1. **Internal Defaults** (`clink/constants.py` lines 30-35) already provide:
```python
"gemini": CLIInternalDefaults(
    parser="gemini_json",
    additional_args=["-o", "json"],  # First -o json
    ...
)
```

2. **User Config** (`conf/cli_clients/gemini.json`) duplicated it:
```json
"additional_args": [
  "--telemetry", "false",
  "--yolo",
  "-o", "json"  // Second -o json (DUPLICATE!)
]
```

When combined in `clink/registry.py` and `clink/agents/base.py`, this resulted in:
```bash
gemini -o json --telemetry false --yolo -o json
```

The duplicate `-o json` flag caused Gemini CLI to malfunction and output plain text, leading to parser errors.

## Changes Made

- [x] Removed duplicate `-o json` from `conf/cli_clients/gemini.json`
- [x] Kept only `--telemetry false --yolo` in config file
- [x] No other changes needed (`-o json` still provided by internal defaults)

## Impact

**Before (Broken):**
```
Command: gemini -o json --telemetry false --yolo -o json
Output: "8\n<SUMMARY>..." (plain text)
Error: Failed to decode Gemini CLI JSON output
```

**After (Fixed):**
```
Command: gemini -o json --telemetry false --yolo
Output: {"response": "8", "stats": {...}} (valid JSON)
Status: success
```

## Testing

- [x] Manual testing: Verified Gemini CLI returns valid JSON
- [x] Parser testing: Confirmed clink successfully parses response
- [x] Configuration validated: Matches pattern used by claude/codex configs
- [x] No breaking changes

## Related Issues

Fixes #291

## Checklist

- [x] PR title follows conventional commits format
- [x] Self-review completed
- [x] Configuration change is minimal and targeted
- [x] No code changes required (config-only fix)
- [x] Tested with realistic scenarios
- [x] Ready for review