### PR TITLE
fix:Add --skip-git-repo-check flag to codex CLI config

### DIFF
--- a/conf/cli_clients/codex.json
+++ b/conf/cli_clients/codex.json
@@ -3,7 +3,8 @@
   "command": "codex",
   "additional_args": [
     "--json",
-    "--dangerously-bypass-approvals-and-sandbox"
+    "--dangerously-bypass-approvals-and-sandbox",
+    "--skip-git-repo-check"
   ],
   "env": {},
   "roles": {


### PR DESCRIPTION
## Problem
The codex CLI fails with 'Not inside a trusted directory' errors when invoked via MCP servers or other non-interactive contexts, preventing the clink tool from working correctly.

## Solution
Add the `--skip-git-repo-check` flag to the codex CLI configuration, allowing it to work in any directory context.

## Benefits
- Enables codex to work reliably through MCP servers
- No impact on security (the flag only skips directory trust checks, doesn't bypass other security features)
- Makes the clink tool more robust in varied execution environments

## Testing
Tested with zen MCP server via Claude Code - codex now works correctly without directory trust errors.