### PR TITLE
feat: Add thinking_mode and execution_mode support for CLI agents

### DIFF
--- a/clink/agents/claude.py
+++ b/clink/agents/claude.py
@@ -11,7 +11,18 @@ from .base import AgentOutput, BaseCLIAgent
 class ClaudeAgent(BaseCLIAgent):
     """Claude CLI agent with system-prompt injection support."""
 
-    def _build_command(self, *, role: ResolvedCLIRole, system_prompt: str | None) -> list[str]:
+    def _build_command(
+        self,
+        *,
+        role: ResolvedCLIRole,
+        system_prompt: str | None,
+        thinking_mode: str | None = None,
+        execution_mode: str | None = None,
+    ) -> list[str]:
+        # NOTE: Claude CLI does not currently support thinking_mode or execution_mode flags.
+        # These parameters are accepted for API compatibility but are not used.
+        _ = (thinking_mode, execution_mode)
+
         command = list(self.client.executable)
         command.extend(self.client.internal_args)
         command.extend(self.client.config_args)

--- a/clink/models.py
+++ b/clink/models.py
@@ -51,6 +51,14 @@ class CLIClientConfig(BaseModel):
     timeout_seconds: PositiveInt | None = Field(default=None)
     roles: dict[str, CLIRoleConfig] = Field(default_factory=dict)
     output_to_file: OutputCaptureConfig | None = None
+    thinking_mode_flag_template: str | None = Field(
+        default=None,
+        description="Optional CLI flag template for thinking mode. Use $value for string.Template placeholder.",
+    )
+    execution_mode_flag_template: str | None = Field(
+        default=None,
+        description="Optional CLI flag template for execution mode. Use $value for string.Template placeholder.",
+    )
 
     @field_validator("additional_args", mode="before")
     @classmethod
@@ -87,6 +95,14 @@ class ResolvedCLIClient(BaseModel):
     runner: str | None = None
     roles: dict[str, ResolvedCLIRole]
     output_to_file: OutputCaptureConfig | None = None
+    thinking_mode_flag_template: str | None = Field(
+        default=None,
+        description="Optional CLI flag template for thinking mode. Use $value for string.Template placeholder.",
+    )
+    execution_mode_flag_template: str | None = Field(
+        default=None,
+        description="Optional CLI flag template for execution mode. Use $value for string.Template placeholder.",
+    )
 
     def list_roles(self) -> list[str]:
         return list(self.roles.keys())

--- a/clink/registry.py
+++ b/clink/registry.py
@@ -169,6 +169,8 @@ class ClinkRegistry:
             roles=roles,
             output_to_file=output_to_file,
             working_dir=working_dir,
+            thinking_mode_flag_template=raw.thinking_mode_flag_template,
+            execution_mode_flag_template=raw.execution_mode_flag_template,
         )
 
     def _resolve_executable(

--- a/conf/cli_clients/codex.json
+++ b/conf/cli_clients/codex.json
@@ -6,6 +6,8 @@
     "--dangerously-bypass-approvals-and-sandbox"
   ],
   "env": {},
+  "thinking_mode_flag_template": "--thinking-mode $value",
+  "execution_mode_flag_template": "--execution-mode $value",
   "roles": {
     "default": {
       "prompt_path": "systemprompts/clink/default.txt",

--- a/conf/cli_clients/gemini.json
+++ b/conf/cli_clients/gemini.json
@@ -5,6 +5,8 @@
     "--yolo"
   ],
   "env": {},
+  "thinking_mode_flag_template": "--thinking-mode $value",
+  "execution_mode_flag_template": "--execution-mode $value",
   "roles": {
     "default": {
       "prompt_path": "systemprompts/clink/default.txt",


### PR DESCRIPTION
Enables dynamic control of thinking/execution modes for Gemini and Codex CLIs, allowing users to optimize cost vs quality trade-offs per request.

## Features

- **Dynamic Mode Flags**: Template-based flag injection for CLIs
  - Gemini: --thinking-mode {minimal,low,medium,high,max}
  - Codex: --thinking-mode {extended,heavy}
  - Claude: API compatible (accepts but ignores parameters)

- **Security**: Multiple layers of protection
  - Token-safe substitution prevents argument injection
  - Input validation with allowlists
  - Template format: $value (not {value})

- **Schema Integration**: Modes discoverable via MCP schema
  - thinking_mode: Optional string with allowed values
  - execution_mode: Optional string for execution control

## Implementation

### Modified Files

- **clink/agents/base.py**: Token-safe flag injection logic
- **clink/agents/claude.py**: API compatibility wrapper
- **clink/models.py**: Template field definitions
- **clink/registry.py**: Config propagation
- **tools/clink.py**: Schema exposure + validation
- **conf/cli_clients/{gemini,codex}.json**: Flag templates

### Security Fixes

1. **Argument Injection Prevention**: ```python # Before (vulnerable): shlex.split(rendered)  # "max --evil" → ['max', '--evil']

   # After (secure): base.append(thinking_mode)  # Single argv element ```

2. **Input Validation**:
   - Allowlist: {minimal, low, medium, high, max, extended, heavy}
   - Clear error messages for invalid values

3. **Template Safety**:
   - Format: \`--thinking-mode \$value\` (string.Template compatible)
   - Pre-tokenize template, insert value as single token

## Testing

- ✅ Python syntax validation
- ✅ Registry loading (3 CLI clients)
- ✅ Template rendering (normal + injection attempts)
- ✅ Command building (Gemini, Codex, Claude)
- ✅ Security: Injection attacks safely blocked

## Multi-Model Review

- **Gemini CLI**: ✅ APPROVE (Security verified)
- **Codex CLI**: ✅ APPROVE (All critical issues resolved)

## Breaking Changes

None. Backward compatible:
- New parameters are optional
- Existing configs work without modification
- Claude CLI maintains current behavior

🤖 Generated with Multi-Model Collaboration (Claude Code + Gemini + Codex)

## PR Title Format

**Please ensure your PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format:**

### Version Bumping Types (trigger semantic release):
- `feat: <description>` - New features → **MINOR** version bump (1.1.0 → 1.2.0)
- `fix: <description>` - Bug fixes → **PATCH** version bump (1.1.0 → 1.1.1) 
- `perf: <description>` - Performance improvements → **PATCH** version bump (1.1.0 → 1.1.1)

### Breaking Changes (trigger MAJOR version bump):
For breaking changes, use any commit type above with `BREAKING CHANGE:` in the commit body or `!` after the type:
- `feat!: <description>` → **MAJOR** version bump (1.1.0 → 2.0.0)
- `fix!: <description>` → **MAJOR** version bump (1.1.0 → 2.0.0)

### Non-Versioning Types (no release):
- `build: <description>` - Build system changes
- `chore: <description>` - Maintenance tasks
- `ci: <description>` - CI/CD changes
- `docs: <description>` - Documentation only
- `refactor: <description>` - Code refactoring (no functional changes)
- `style: <description>` - Code style/formatting changes
- `test: <description>` - Test additions/changes

### Docker Build Triggering:

Docker builds are **independent** of versioning and trigger based on:

**Automatic**: When PRs modify relevant files:
- Python files (`*.py`), `requirements*.txt`, `pyproject.toml`
- Docker files (`Dockerfile`, `docker-compose.yml`, `.dockerignore`)

**Manual**: Add the `docker-build` label to force builds for any PR.

## Description

Please provide a clear and concise description of what this PR does.

## Changes Made

- [ ] List the specific changes made
- [ ] Include any breaking changes
- [ ] Note any dependencies added/removed

## Testing

**Please review our [Testing Guide](../docs/testing.md) before submitting.**

### Run all linting and tests (required):
```bash
# Activate virtual environment first
source venv/bin/activate

# Run comprehensive code quality checks (recommended)
./code_quality_checks.sh

# If you made tool changes, also run simulator tests
python communication_simulator_test.py
```

- [ ] All linting passes (ruff, black, isort)
- [ ] All unit tests pass
- [ ] **For new features**: Unit tests added in `tests/`
- [ ] **For tool changes**: Simulator tests added in `simulator_tests/`
- [ ] **For bug fixes**: Tests added to prevent regression
- [ ] Simulator tests pass (if applicable)
- [ ] Manual testing completed with realistic scenarios

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] PR title follows the format guidelines above
- [ ] **Activated venv and ran code quality checks: `source venv/bin/activate && ./code_quality_checks.sh`**
- [ ] Self-review completed
- [ ] **Tests added for ALL changes** (see Testing section above)
- [ ] Documentation updated as needed
- [ ] All unit tests passing
- [ ] Relevant simulator tests passing (if tool changes)
- [ ] Ready for review

## Additional Notes

Any additional information that reviewers should know.