### PR TITLE
fix(server): iterate provider instances during shutdown

### DIFF
--- a/server.py
+++ b/server.py
@@ -572,7 +572,8 @@ def configure_providers():
         try:
             registry = ModelProviderRegistry()
             if hasattr(registry, "_initialized_providers"):
-                for provider in list(registry._initialized_providers.items()):
+                # Iterate over provider instances (values), not (type, instance) tuples
+                for provider in list(registry._initialized_providers.values()):
                     try:
                         if provider and hasattr(provider, "close"):
                             provider.close()


### PR DESCRIPTION
# fix(server): iterate provider instances during shutdown

## Summary

Fixes provider cleanup bug where `close()` methods are never called, causing resource leaks (unclosed HTTP connections, socket leaks) in long-running processes.

## Problem

The `cleanup_providers()` function iterates over `.items()` which returns `(ProviderType, Provider)` tuples:
```python
for provider in list(registry._initialized_providers.items()):
    if provider and hasattr(provider, "close"):  # ❌ Checks tuple, not provider
        provider.close()  # Never executes!
```

**Root Cause**: `hasattr(tuple, "close")` always returns `False`, so cleanup never happens.

**Impact**:
- Unclosed httpx.AsyncClient instances
- Socket file descriptor leaks over time
- ResourceWarning messages on process exit

## Solution

Change `.items()` to `.values()` to iterate over provider instances only:
```python
for provider in list(registry._initialized_providers.values()):  # ✅ Instances only
    if provider and hasattr(provider, "close"):
        provider.close()
```

This is a **one-word fix** that restores intended cleanup behavior.

## Test Plan

- [x] All linting and tests pass
- [x] Manual verification:
  ```bash
  # Start server with DIAL provider
  export DIAL_API_KEY="test-key"
  python server.py &
  PID=$!

  # Check for resource warnings on shutdown
  kill $PID
  wait $PID 2>&1 | grep -i "unclosed"
  # Expected: No "unclosed httpx.AsyncClient" warnings
  ```
- [x] Code review confirms `.values()` returns provider instances

## Changes

**File Modified**: `server.py` (Line 576)

```diff
 def cleanup_providers():
     """Cleanup all initialized providers on shutdown."""
     registry = ModelProviderRegistry()
-    for provider in list(registry._initialized_providers.items()):
+    # Iterate over provider instances (values), not (type, instance) tuples
+    for provider in list(registry._initialized_providers.values()):
         try:
             if provider and hasattr(provider, "close"):
                 provider.close()
```

## Related Issues

Fixes resource leak in provider cleanup (main branch).

**Severity**: High
**Priority**: P1

## Checklist

- [x] PR title follows conventional commits format
- [x] Activated venv and ran code quality checks: `./code_quality_checks.sh`
- [x] Self-review completed
- [x] All unit tests passing
- [x] No breaking changes (pure bug fix)
- [x] Ready for review
