### PR TITLE
fix(openrouter): remove trailing comma in JSON config

### DIFF
--- a/conf/openrouter_models.json
+++ b/conf/openrouter_models.json
@@ -110,7 +110,7 @@
       "model_name": "google/gemini-2.5-pro",
       "aliases": [
         "gemini-2.5",
-        "pro-2.5-openrouter",
+        "pro-2.5-openrouter"
       ],
       "context_window": 1048576,
       "max_output_tokens": 65536,


### PR DESCRIPTION
## Description

Fixes JSON syntax error in openrouter_models.json introduced in commit bbfdfac.

## Problem

The gemini-2.5-pro model configuration had a trailing comma in the aliases array (line 113), which caused JSON parsing to fail:

```json
"aliases": [
  "gemini-2.5",
  "pro-2.5-openrouter",  // ❌ trailing comma
],
```

## Solution

Removed the trailing comma to fix JSON syntax:

```json
"aliases": [
  "gemini-2.5",
  "pro-2.5-openrouter"  // ✅ no trailing comma
],
```

## Verification

```bash
# Before fix
python -m json.tool conf/openrouter_models.json
# ❌ JSON parsing error

# After fix  
python -m json.tool conf/openrouter_models.json
# ✅ Valid JSON
```

## Testing

- [x] JSON syntax validation passes
- [x] No functional changes
- [x] Configuration file loads correctly

## Related

Fixes syntax error from commit bbfdfac (feat: Gemini 3.0 Pro Preview for Open Router)