### PR TITLE
feat: add support for xAI Grok 4.1 Fast, Grok 4.1 Fast Non-Reasoning, grok-code-fast-1 models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,8 +55,9 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 
 # Optional: Default model to use
 # Options: 'auto' (Claude picks best model), 'pro', 'flash', 'o3', 'o3-mini', 'o4-mini', 'o4-mini-high',
-#          'gpt-5.1', 'gpt-5.1-codex', 'gpt-5.1-codex-mini', 'gpt-5', 'gpt-5-mini', 'grok',
-#          'opus-4.1', 'sonnet-4.1', or any DIAL model if DIAL is configured
+#          'gpt-5.1', 'gpt-5.1-codex', 'gpt-5.1-codex-mini', 'gpt-5', 'gpt-5-mini', 'grok' (alias for grok-4-1-fast),
+#          'grok-4-1-fast', 'grok-4-1-fast-non-reasoning', 'grok-code-fast-1', 'opus-4.1', 'sonnet-4.1',
+#          or any DIAL model if DIAL is configured
 # When set to 'auto', Claude will select the best model for each task
 # Defaults to 'auto' if not specified
 DEFAULT_MODEL=auto
@@ -98,11 +99,16 @@ DEFAULT_THINKING_MODE_THINKDEEP=high
 #   - pro                               (shorthand for gemini-2.5-pro)
 #
 # Supported X.AI GROK models:
-#   - grok-3          (131K context, advanced reasoning)
-#   - grok-3-fast     (131K context, higher performance but more expensive)
-#   - grok            (shorthand for grok-3)
-#   - grok3           (shorthand for grok-3)
-#   - grokfast        (shorthand for grok-3-fast)
+#   - grok-4-1-fast               (2M context, fast reasoning; `grok` alias resolves here)
+#   - grok                        (shorthand for grok-4-1-fast)
+#   - grok-4-1-fast-non-reasoning (2M context, ultra-fast text-to-text without reasoning)
+#   - grok-code-fast-1            (256K context, coding-specialized; streaming + tool calling)
+#   - grok-4                      (256K context, advanced reasoning)
+#   - grok4                       (shorthand for grok-4)
+#   - grok-3                      (131K context, advanced reasoning)
+#   - grok-3-fast                 (131K context, higher performance but more expensive)
+#   - grok3                       (shorthand for grok-3)
+#   - grokfast                    (shorthand for grok-3-fast)
 #
 # Supported DIAL models (when available in your DIAL deployment):
 #   - o3-2025-04-16   (200K context, latest O3 release)
@@ -128,10 +134,12 @@ DEFAULT_THINKING_MODE_THINKDEEP=high
 #   OPENAI_ALLOWED_MODELS=o3-mini,o4-mini,mini  # Only allow mini models (cost control)
 #   OPENAI_ALLOWED_MODELS=gpt-5.1,gpt-5.1-codex  # Pin to GPT-5.1 family
 #   GOOGLE_ALLOWED_MODELS=flash                  # Only allow Flash (fast responses)
-#   XAI_ALLOWED_MODELS=grok-3                    # Only allow standard GROK (not fast variant)
+#   XAI_ALLOWED_MODELS=grok-4-1-fast             # Pin to latest flagship (grok alias resolves here)
+#   XAI_ALLOWED_MODELS=grok,grok-code-fast-1     # Grok 4.1 Fast Reasoning + coding models
+#   XAI_ALLOWED_MODELS=grok-4                    # Only allow standard GROK (not fast variant)
 #   OPENAI_ALLOWED_MODELS=o4-mini                # Single model standardization
 #   GOOGLE_ALLOWED_MODELS=flash,pro              # Allow both Gemini models
-#   XAI_ALLOWED_MODELS=grok,grok-3-fast          # Allow both GROK variants
+#   XAI_ALLOWED_MODELS=grok,grok-4               # Allow both GROK variants
 #   DIAL_ALLOWED_MODELS=o3,o4-mini                       # Only allow O3/O4 models via DIAL
 #   DIAL_ALLOWED_MODELS=opus-4.1,sonnet-4.1                  # Only Claude 4.1 models (without thinking)
 #   DIAL_ALLOWED_MODELS=opus-4.1-thinking,sonnet-4.1-thinking # Only Claude 4.1 with thinking mode

--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 # Optional: Default model to use
 # Options: 'auto' (Claude picks best model), 'pro', 'flash', 'o3', 'o3-mini', 'o4-mini', 'o4-mini-high',
 #          'gpt-5.1', 'gpt-5.1-codex', 'gpt-5.1-codex-mini', 'gpt-5', 'gpt-5-mini', 'grok' (alias for grok-4-1-fast),
-#          'grok-4-1-fast', 'grok-4-1-fast-non-reasoning', 'grok-code-fast-1', 'opus-4.1', 'sonnet-4.1',
+#          'grok-4-1-fast', 'grok-4-fast', 'grok-4-fast-non-reasoning', 'grok-code-fast-1', 'opus-4.1', 'sonnet-4.1',
 #          or any DIAL model if DIAL is configured
 # When set to 'auto', Claude will select the best model for each task
 # Defaults to 'auto' if not specified
@@ -102,6 +102,8 @@ DEFAULT_THINKING_MODE_THINKDEEP=high
 #   - grok-4-1-fast               (2M context, fast reasoning; `grok` alias resolves here)
 #   - grok                        (shorthand for grok-4-1-fast)
 #   - grok-4-1-fast-non-reasoning (2M context, ultra-fast text-to-text without reasoning)
+#   - grok-4-fast                 (2M context, fast reasoning; vision support)
+#   - grok-4-fast-non-reasoning   (2M context, ultra-fast text-to-text without reasoning)
 #   - grok-code-fast-1            (256K context, coding-specialized; streaming + tool calling)
 #   - grok-4                      (256K context, advanced reasoning)
 #   - grok4                       (shorthand for grok-4)
@@ -136,6 +138,7 @@ DEFAULT_THINKING_MODE_THINKDEEP=high
 #   GOOGLE_ALLOWED_MODELS=flash                  # Only allow Flash (fast responses)
 #   XAI_ALLOWED_MODELS=grok-4-1-fast             # Pin to latest flagship (grok alias resolves here)
 #   XAI_ALLOWED_MODELS=grok,grok-code-fast-1     # Grok 4.1 Fast Reasoning + coding models
+#   XAI_ALLOWED_MODELS=grok-4-fast               # Pin to Grok 4 Fast Reasoning
 #   XAI_ALLOWED_MODELS=grok-4                    # Only allow standard GROK (not fast variant)
 #   OPENAI_ALLOWED_MODELS=o4-mini                # Single model standardization
 #   GOOGLE_ALLOWED_MODELS=flash,pro              # Allow both Gemini models

--- a/conf/openrouter_models.json
+++ b/conf/openrouter_models.json
@@ -450,6 +450,45 @@
       "temperature_constraint": "range",
       "description": "xAI's Grok 4 via OpenRouter with vision and advanced reasoning",
       "intelligence_score": 15
+    },
+    {
+      "model_name": "x-ai/grok-4-fast",
+      "aliases": [
+        "grok-4-fast",
+        "grok4fast",
+        "grok-4-fast-reasoning"
+      ],
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": true,
+      "supports_json_mode": true,
+      "supports_function_calling": true,
+      "supports_images": true,
+      "max_image_size_mb": 20.0,
+      "supports_temperature": true,
+      "temperature_constraint": "range",
+      "description": "xAI's Grok 4 Fast via OpenRouter - Cost-efficient reasoning model with 2M context window",
+      "intelligence_score": 15
+    },
+    {
+      "model_name": "x-ai/grok-code-fast-1",
+      "aliases": [
+        "grok-code-fast",
+        "grok-code-fast-1",
+        "grokcodefast"
+      ],
+      "context_window": 256000,
+      "max_output_tokens": 256000,
+      "supports_extended_thinking": true,
+      "supports_json_mode": true,
+      "supports_function_calling": true,
+      "supports_images": false,
+      "max_image_size_mb": 0.0,
+      "supports_temperature": true,
+      "temperature_constraint": "range",
+      "allow_code_generation": true,
+      "description": "xAI's Grok Code Fast 1 via OpenRouter - Speedy and economical reasoning model specialized for agentic coding",
+      "intelligence_score": 14
     }
   ]
 }

--- a/conf/openrouter_models.json
+++ b/conf/openrouter_models.json
@@ -470,11 +470,10 @@
       "intelligence_score": 15
     },
     {
-      "model_name": "x-ai/grok-4-fast",
+      "model_name": "x-ai/grok-4.1-fast",
       "aliases": [
-        "grok-4-fast",
-        "grok4fast",
-        "grok-4-fast-reasoning"
+        "grok-4-1-fast",
+        "grok-4-1-fast-reasoning"
       ],
       "context_window": 2000000,
       "max_output_tokens": 2000000,
@@ -485,7 +484,7 @@
       "max_image_size_mb": 20.0,
       "supports_temperature": true,
       "temperature_constraint": "range",
-      "description": "xAI's Grok 4 Fast via OpenRouter - Cost-efficient reasoning model with 2M context window",
+      "description": "xAI's Grok 4.1 Fast via OpenRouter - Best agentic tool calling model that shines in real-world use cases like customer support and deep research. 2M context window. Reasoning can be enabled/disabled using the reasoning parameter.",
       "intelligence_score": 15
     },
     {

--- a/conf/openrouter_models.json
+++ b/conf/openrouter_models.json
@@ -454,8 +454,7 @@
       "model_name": "x-ai/grok-4",
       "aliases": [
         "grok-4",
-        "grok4",
-        "grok"
+        "grok4"
       ],
       "context_window": 256000,
       "max_output_tokens": 256000,
@@ -472,6 +471,7 @@
     {
       "model_name": "x-ai/grok-4.1-fast",
       "aliases": [
+        "grok",
         "grok-4-1-fast",
         "grok-4-1-fast-reasoning"
       ],

--- a/conf/openrouter_models.json
+++ b/conf/openrouter_models.json
@@ -488,6 +488,44 @@
       "intelligence_score": 15
     },
     {
+      "model_name": "x-ai/grok-4-fast",
+      "aliases": [
+        "grok-4-fast",
+        "grok-4-fast-reasoning",
+        "grok-4-fast-reasoning-latest",
+        "grok4fast"
+      ],
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": true,
+      "supports_json_mode": true,
+      "supports_function_calling": true,
+      "supports_images": true,
+      "max_image_size_mb": 20.0,
+      "supports_temperature": true,
+      "temperature_constraint": "range",
+      "description": "xAI's Grok 4 Fast via OpenRouter - 2M context window with reasoning capabilities and vision support. Reasoning can be enabled/disabled using the reasoning parameter.",
+      "intelligence_score": 15
+    },
+    {
+      "model_name": "x-ai/grok-4-fast-non-reasoning",
+      "aliases": [
+        "grok-4-fast-non-reasoning",
+        "grok4fast-nr"
+      ],
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": false,
+      "supports_json_mode": true,
+      "supports_function_calling": true,
+      "supports_images": false,
+      "max_image_size_mb": 0.0,
+      "supports_temperature": true,
+      "temperature_constraint": "range",
+      "description": "xAI's Grok 4 Fast Non-Reasoning via OpenRouter - 2M context window without reasoning overhead for faster responses (text-only).",
+      "intelligence_score": 13
+    },
+    {
       "model_name": "x-ai/grok-code-fast-1",
       "aliases": [
         "grok-code-fast",

--- a/conf/xai_models.json
+++ b/conf/xai_models.json
@@ -107,7 +107,7 @@
       "model_name": "grok-4-1-fast-non-reasoning",
       "friendly_name": "X.AI (Grok 4.1 Fast Non-Reasoning)",
       "aliases": [
-        "grok-4-1-fast-non-reasoning"
+        "grok-4-1-fast-non-reasoning-latest"
       ],
       "intelligence_score": 13,
       "description": "GROK-4.1 Fast Non-Reasoning (2M context) - Ultra-fast text-to-text generation optimized for speed and stability without advanced reasoning",

--- a/conf/xai_models.json
+++ b/conf/xai_models.json
@@ -82,6 +82,67 @@
       "supports_json_mode": false,
       "supports_images": false,
       "supports_temperature": true
+    },
+    {
+      "model_name": "grok-4-fast",
+      "friendly_name": "X.AI (Grok 4 Fast Reasoning)",
+      "aliases": [
+        "grok-4-fast-reasoning",
+        "grok4fast",
+        "grok-4-fast-reasoning-latest"
+      ],
+      "intelligence_score": 15,
+      "description": "GROK-4 Fast Reasoning (2M context) - Cost-efficient reasoning model with frontier-level performance and exceptional token efficiency",
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": true,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": true,
+      "supports_temperature": true,
+      "max_image_size_mb": 20.0
+    },
+    {
+      "model_name": "grok-4-fast-non-reasoning",
+      "friendly_name": "X.AI (Grok 4 Fast Non-Reasoning)",
+      "aliases": [
+        "grok-4-fast-non-reasoning",
+        "grok4fast-non-reasoning"
+      ],
+      "intelligence_score": 13,
+      "description": "GROK-4 Fast Non-Reasoning (2M context) - Ultra-fast text-to-text generation optimized for speed and stability without advanced reasoning",
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": false,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true
+    },
+    {
+      "model_name": "grok-code-fast-1",
+      "friendly_name": "X.AI (Grok Code Fast 1)",
+      "aliases": [
+        "grok-code-fast",
+        "grok-code-fast-1-0825",
+        "grokcodefast"
+      ],
+      "intelligence_score": 14,
+      "description": "GROK Code Fast 1 (256K context) - Speedy and economical reasoning model specialized for agentic coding workflows",
+      "context_window": 256000,
+      "max_output_tokens": 256000,
+      "supports_extended_thinking": true,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true,
+      "allow_code_generation": true
     }
   ]
 }

--- a/conf/xai_models.json
+++ b/conf/xai_models.json
@@ -28,9 +28,7 @@
       "model_name": "grok-4",
       "friendly_name": "X.AI (Grok 4)",
       "aliases": [
-        "grok",
-        "grok4",
-        "grok-4"
+        "grok4"
       ],
       "intelligence_score": 16,
       "description": "GROK-4 (256K context) - Frontier multimodal reasoning model with advanced capabilities",
@@ -87,6 +85,7 @@
       "model_name": "grok-4-1-fast",
       "friendly_name": "X.AI (Grok 4.1 Fast Reasoning)",
       "aliases": [
+        "grok",
         "grok-4-1-fast-reasoning",
         "grok-4-1-fast-reasoning-latest"
       ],

--- a/conf/xai_models.json
+++ b/conf/xai_models.json
@@ -84,15 +84,14 @@
       "supports_temperature": true
     },
     {
-      "model_name": "grok-4-fast",
-      "friendly_name": "X.AI (Grok 4 Fast Reasoning)",
+      "model_name": "grok-4-1-fast",
+      "friendly_name": "X.AI (Grok 4.1 Fast Reasoning)",
       "aliases": [
-        "grok-4-fast-reasoning",
-        "grok4fast",
-        "grok-4-fast-reasoning-latest"
+        "grok-4-1-fast-reasoning",
+        "grok-4-1-fast-reasoning-latest"
       ],
       "intelligence_score": 15,
-      "description": "GROK-4 Fast Reasoning (2M context) - Cost-efficient reasoning model with frontier-level performance and exceptional token efficiency",
+      "description": "GROK-4.1 Fast Reasoning (2M context) - Frontier multimodal model optimized for high-performance agentic tool calling with cost-efficient reasoning and exceptional token efficiency",
       "context_window": 2000000,
       "max_output_tokens": 2000000,
       "supports_extended_thinking": true,
@@ -105,14 +104,13 @@
       "max_image_size_mb": 20.0
     },
     {
-      "model_name": "grok-4-fast-non-reasoning",
-      "friendly_name": "X.AI (Grok 4 Fast Non-Reasoning)",
+      "model_name": "grok-4-1-fast-non-reasoning",
+      "friendly_name": "X.AI (Grok 4.1 Fast Non-Reasoning)",
       "aliases": [
-        "grok-4-fast-non-reasoning",
-        "grok4fast-non-reasoning"
+        "grok-4-1-fast-non-reasoning"
       ],
       "intelligence_score": 13,
-      "description": "GROK-4 Fast Non-Reasoning (2M context) - Ultra-fast text-to-text generation optimized for speed and stability without advanced reasoning",
+      "description": "GROK-4.1 Fast Non-Reasoning (2M context) - Ultra-fast text-to-text generation optimized for speed and stability without advanced reasoning",
       "context_window": 2000000,
       "max_output_tokens": 2000000,
       "supports_extended_thinking": false,

--- a/conf/xai_models.json
+++ b/conf/xai_models.json
@@ -121,6 +121,45 @@
       "supports_temperature": true
     },
     {
+      "model_name": "grok-4-fast",
+      "friendly_name": "X.AI (Grok 4 Fast Reasoning)",
+      "aliases": [
+        "grok-4-fast-reasoning",
+        "grok-4-fast-reasoning-latest",
+        "grok4fast"
+      ],
+      "intelligence_score": 15,
+      "description": "GROK-4 Fast Reasoning (2M context) - Cost-efficient frontier reasoning model with 98% lower cost vs Grok 4 while achieving comparable benchmark performance",
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": true,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": true,
+      "supports_temperature": true,
+      "max_image_size_mb": 20.0
+    },
+    {
+      "model_name": "grok-4-fast-non-reasoning",
+      "friendly_name": "X.AI (Grok 4 Fast Non-Reasoning)",
+      "aliases": [
+        "grok-4-fast-non-reasoning-latest"
+      ],
+      "intelligence_score": 13,
+      "description": "GROK-4 Fast Non-Reasoning (2M context) - Ultra-fast text generation optimized for low latency without reasoning overhead",
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": false,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true
+    },
+    {
       "model_name": "grok-code-fast-1",
       "friendly_name": "X.AI (Grok Code Fast 1)",
       "aliases": [

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -4,16 +4,33 @@ This guide covers advanced features, configuration options, and workflows for po
 
 ## Table of Contents
 
-- [Model Configuration](#model-configuration)
-- [Model Usage Restrictions](#model-usage-restrictions)
-- [Thinking Modes](#thinking-modes)
-- [Tool Parameters](#tool-parameters)
-- [Context Revival: AI Memory Beyond Context Limits](#context-revival-ai-memory-beyond-context-limits)
-- [Collaborative Workflows](#collaborative-workflows)
-- [Working with Large Prompts](#working-with-large-prompts)
-- [Vision Support](#vision-support)
-- [Web Search Integration](#web-search-integration)
-- [System Prompts](#system-prompts)
+- [Advanced Usage Guide](#advanced-usage-guide)
+  - [Table of Contents](#table-of-contents)
+  - [Model Configuration](#model-configuration)
+  - [Model Usage Restrictions](#model-usage-restrictions)
+  - [Thinking Modes](#thinking-modes)
+    - [Thinking Modes \& Token Budgets](#thinking-modes--token-budgets)
+    - [How to Use Thinking Modes](#how-to-use-thinking-modes)
+      - [Optimizing Token Usage \& Costs](#optimizing-token-usage--costs)
+  - [Tool Parameters](#tool-parameters)
+    - [File-Processing Tools](#file-processing-tools)
+  - [Context Revival: AI Memory Beyond Context Limits](#context-revival-ai-memory-beyond-context-limits)
+    - [**The Breakthrough**](#the-breakthrough)
+    - [Key Benefits](#key-benefits)
+    - [Quick Example](#quick-example)
+  - [Collaborative Workflows](#collaborative-workflows)
+    - [Design → Review → Implement](#design--review--implement)
+    - [Code → Review → Fix](#code--review--fix)
+    - [Debug → Analyze → Solution → Precommit Check → Publish](#debug--analyze--solution--precommit-check--publish)
+    - [Refactor → Review → Implement → Test](#refactor--review--implement--test)
+    - [Tool Selection Guidance](#tool-selection-guidance)
+  - [Vision Support](#vision-support)
+  - [Working with Large Prompts](#working-with-large-prompts)
+  - [Web Search Integration](#web-search-integration)
+  - [System Prompts](#system-prompts)
+    - [Prompt Architecture](#prompt-architecture)
+    - [Specialized Expertise](#specialized-expertise)
+    - [Customization](#customization)
 
 ## Model Configuration
 
@@ -48,6 +65,9 @@ Regardless of your default configuration, you can specify models per request:
 | **`gpt5-mini`** (GPT-5 Mini) | OpenAI | 400K tokens | Efficient variant with reasoning | Balanced performance and capability |
 | **`gpt5-nano`** (GPT-5 Nano) | OpenAI | 400K tokens | Fastest, cheapest GPT-5 variant | Summarization and classification tasks |
 | **`grok-4`** | X.AI | 256K tokens | Latest flagship Grok model with reasoning, vision | Complex analysis, reasoning tasks |
+| **`grok-4-1-fast`** (Grok 4.1 Fast Reasoning) | X.AI | 2M tokens | Frontier multimodal model optimized for high-performance agentic tool calling with cost-efficient reasoning | Complex analysis, cost-conscious reasoning tasks |
+| **`grok-code-fast-1`** (Grok Code Fast 1) | X.AI | 256K tokens | Speedy reasoning model specialized for agentic coding | Fast coding workflows, agentic development |
+| **`grok-4-1-fast-non-reasoning`** (Grok 4.1 Fast Non-Reasoning) | X.AI | 2M tokens | Ultra-fast text-to-text generation without reasoning | Rapid text processing, high-throughput tasks |
 | **`grok-3`** | X.AI | 131K tokens | Advanced reasoning model | Deep analysis, complex problems |
 | **`grok-3-fast`** | X.AI | 131K tokens | Higher performance variant | Fast responses with reasoning |
 | **`llama`** (Llama 3.2) | Custom/Local | 128K tokens | Local inference, privacy | On-device analysis, cost-free processing |
@@ -72,6 +92,10 @@ cloud models (expensive/powerful) AND local models (free/private) in the same co
   - **GPT-5**: Full-featured with reasoning support and vision
   - **GPT-5 Mini**: Balanced efficiency and capability
   - **GPT-5 Nano**: Optimized for fast, low-cost tasks
+- **Grok-4 Fast Series**: Latest cost-efficient models with 2M context
+  - **Grok-4 Fast Reasoning**: Cost-efficient reasoning with frontier-level performance
+  - **Grok-4 Fast Non-Reasoning**: Ultra-fast text-to-text generation without reasoning
+- **Grok Code Fast 1**: Specialized for agentic coding workflows, 256K context
 - **Grok-4**: Extended thinking support, vision capabilities, 256K context
 - **Grok-3 Models**: Advanced reasoning, 131K context
 
@@ -168,7 +192,7 @@ All tools that work with files support **both individual files and entire direct
 **`analyze`** - Analyze files or directories
 - `files`: List of file paths or directories (required)
 - `question`: What to analyze (required)  
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `analysis_type`: architecture|performance|security|quality|general
 - `output_format`: summary|detailed|actionable
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)
@@ -183,7 +207,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`codereview`** - Review code files or directories
 - `files`: List of file paths or directories (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `review_type`: full|security|performance|quick
 - `focus_on`: Specific aspects to focus on
 - `standards`: Coding standards to enforce
@@ -199,7 +223,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`debug`** - Debug with file context
 - `error_description`: Description of the issue (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `error_context`: Stack trace or logs
 - `files`: Files or directories related to the issue
 - `runtime_info`: Environment details
@@ -215,7 +239,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`thinkdeep`** - Extended analysis with file context
 - `current_analysis`: Your current thinking (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `problem_context`: Additional context
 - `focus_areas`: Specific aspects to focus on
 - `files`: Files or directories for context
@@ -231,7 +255,7 @@ All tools that work with files support **both individual files and entire direct
 **`testgen`** - Comprehensive test generation with edge case coverage
 - `files`: Code files or directories to generate tests for (required)
 - `prompt`: Description of what to test, testing objectives, and scope (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `test_examples`: Optional existing test files as style/pattern reference
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)
 
@@ -246,7 +270,7 @@ All tools that work with files support **both individual files and entire direct
 - `files`: Code files or directories to analyze for refactoring opportunities (required)
 - `prompt`: Description of refactoring goals, context, and specific areas of focus (required)
 - `refactor_type`: codesmells|decompose|modernize|organization (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `focus_areas`: Specific areas to focus on (e.g., 'performance', 'readability', 'maintainability', 'security')
 - `style_guide_examples`: Optional existing code files to use as style/pattern reference
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -66,8 +66,10 @@ Regardless of your default configuration, you can specify models per request:
 | **`gpt5-nano`** (GPT-5 Nano) | OpenAI | 400K tokens | Fastest, cheapest GPT-5 variant | Summarization and classification tasks |
 | **`grok-4`** | X.AI | 256K tokens | Latest flagship Grok model with reasoning, vision | Complex analysis, reasoning tasks |
 | **`grok-4-1-fast`** (Grok 4.1 Fast Reasoning) | X.AI | 2M tokens | Frontier multimodal model optimized for high-performance agentic tool calling with cost-efficient reasoning | Complex analysis, cost-conscious reasoning tasks |
+| **`grok-4-fast`** (Grok 4 Fast Reasoning) | X.AI | 2M tokens | Cost-efficient frontier reasoning model with 98% lower cost than Grok 4 | Complex analysis, cost-conscious reasoning |
 | **`grok-code-fast-1`** (Grok Code Fast 1) | X.AI | 256K tokens | Speedy reasoning model specialized for agentic coding | Fast coding workflows, agentic development |
 | **`grok-4-1-fast-non-reasoning`** (Grok 4.1 Fast Non-Reasoning) | X.AI | 2M tokens | Ultra-fast text-to-text generation without reasoning | Rapid text processing, high-throughput tasks |
+| **`grok-4-fast-non-reasoning`** (Grok 4 Fast Non-Reasoning) | X.AI | 2M tokens | Ultra-fast text generation without reasoning | Rapid text processing, low-latency applications |
 | **`grok-3`** | X.AI | 131K tokens | Advanced reasoning model | Deep analysis, complex problems |
 | **`grok-3-fast`** | X.AI | 131K tokens | Higher performance variant | Fast responses with reasoning |
 | **`llama`** (Llama 3.2) | Custom/Local | 128K tokens | Local inference, privacy | On-device analysis, cost-free processing |
@@ -92,9 +94,12 @@ cloud models (expensive/powerful) AND local models (free/private) in the same co
   - **GPT-5**: Full-featured with reasoning support and vision
   - **GPT-5 Mini**: Balanced efficiency and capability
   - **GPT-5 Nano**: Optimized for fast, low-cost tasks
-- **Grok-4 Fast Series**: Latest cost-efficient models with 2M context
-  - **Grok-4 Fast Reasoning**: Cost-efficient reasoning with frontier-level performance
-  - **Grok-4 Fast Non-Reasoning**: Ultra-fast text-to-text generation without reasoning
+- **Grok-4.1 Fast Series**: Latest cost-efficient models with 2M context
+  - **Grok-4.1 Fast Reasoning**: Cost-efficient reasoning with frontier-level performance
+  - **Grok-4.1 Fast Non-Reasoning**: Ultra-fast text-to-text generation without reasoning
+- **Grok-4 Fast Series**: Cost-efficient models with 2M context
+  - **Grok-4 Fast Reasoning**: 98% cheaper than Grok 4 with comparable performance
+  - **Grok-4 Fast Non-Reasoning**: Ultra-fast text generation without reasoning
 - **Grok Code Fast 1**: Specialized for agentic coding workflows, 256K context
 - **Grok-4**: Extended thinking support, vision capabilities, 256K context
 - **Grok-3 Models**: Advanced reasoning, 131K context
@@ -192,7 +197,7 @@ All tools that work with files support **both individual files and entire direct
 **`analyze`** - Analyze files or directories
 - `files`: List of file paths or directories (required)
 - `question`: What to analyze (required)  
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-4-fast|grok-4-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `analysis_type`: architecture|performance|security|quality|general
 - `output_format`: summary|detailed|actionable
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)
@@ -207,7 +212,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`codereview`** - Review code files or directories
 - `files`: List of file paths or directories (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-4-fast|grok-4-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `review_type`: full|security|performance|quick
 - `focus_on`: Specific aspects to focus on
 - `standards`: Coding standards to enforce
@@ -223,7 +228,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`debug`** - Debug with file context
 - `error_description`: Description of the issue (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-4-fast|grok-4-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `error_context`: Stack trace or logs
 - `files`: Files or directories related to the issue
 - `runtime_info`: Environment details
@@ -239,7 +244,7 @@ All tools that work with files support **both individual files and entire direct
 
 **`thinkdeep`** - Extended analysis with file context
 - `current_analysis`: Your current thinking (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-4-fast|grok-4-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `problem_context`: Additional context
 - `focus_areas`: Specific aspects to focus on
 - `files`: Files or directories for context
@@ -255,7 +260,7 @@ All tools that work with files support **both individual files and entire direct
 **`testgen`** - Comprehensive test generation with edge case coverage
 - `files`: Code files or directories to generate tests for (required)
 - `prompt`: Description of what to test, testing objectives, and scope (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-4-fast|grok-4-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `test_examples`: Optional existing test files as style/pattern reference
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)
 
@@ -270,7 +275,7 @@ All tools that work with files support **both individual files and entire direct
 - `files`: Code files or directories to analyze for refactoring opportunities (required)
 - `prompt`: Description of refactoring goals, context, and specific areas of focus (required)
 - `refactor_type`: codesmells|decompose|modernize|organization (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-4-fast|grok-4-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `focus_areas`: Specific areas to focus on (e.g., 'performance', 'readability', 'maintainability', 'security')
 - `style_guide_examples`: Optional existing code files to use as style/pattern reference
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ DEFAULT_MODEL=auto  # Claude picks best model for each task (recommended)
   |----------|-----------------|-----------------|
   | OpenAI | `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-codex`, `gpt-4.1`, `o3`, `o3-mini`, `o3-pro`, `o4-mini` | `gpt5.1`, `gpt-5.1`, `5.1`, `gpt5.1-codex`, `codex-5.1`, `codex-mini`, `gpt5`, `gpt5pro`, `mini`, `nano`, `codex`, `o3mini`, `o3pro`, `o4mini` |
   | Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`, `gemini-2.0-flash-lite` | `pro`, `gemini-pro`, `flash`, `flash-2.0`, `flashlite` |
-  | X.AI | `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`, `grok-code-fast-1`, `grok-4`, `grok-3`, `grok-3-fast` | `grok-4-1-fast`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`, `grok`, `grok4`, `grok3`, `grok3fast`, `grokfast` |
+  | X.AI | `grok-4-1-fast`, `grok-4-1-fast-non-reasoning`, `grok-code-fast-1`, `grok-4`, `grok-3`, `grok-3-fast` | `grok-4-1-fast-reasoning`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`, `grok`, `grok4`, `grok3`, `grok3fast`, `grokfast` |
   | OpenRouter | See `conf/openrouter_models.json` for the continually evolving catalogue | e.g., `opus`, `sonnet`, `flash`, `pro`, `mistral` |
   | Custom | User-managed entries such as `llama3.2` | Define your own aliases per entry |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ DEFAULT_MODEL=auto  # Claude picks best model for each task (recommended)
   |----------|-----------------|-----------------|
   | OpenAI | `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-codex`, `gpt-4.1`, `o3`, `o3-mini`, `o3-pro`, `o4-mini` | `gpt5.1`, `gpt-5.1`, `5.1`, `gpt5.1-codex`, `codex-5.1`, `codex-mini`, `gpt5`, `gpt5pro`, `mini`, `nano`, `codex`, `o3mini`, `o3pro`, `o4mini` |
   | Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`, `gemini-2.0-flash-lite` | `pro`, `gemini-pro`, `flash`, `flash-2.0`, `flashlite` |
-  | X.AI | `grok-4`, `grok-3`, `grok-3-fast` | `grok`, `grok4`, `grok3`, `grok3fast`, `grokfast` |
+  | X.AI | `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`, `grok-code-fast-1`, `grok-4`, `grok-3`, `grok-3-fast` | `grok-4-1-fast`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`, `grok`, `grok4`, `grok3`, `grok3fast`, `grokfast` |
   | OpenRouter | See `conf/openrouter_models.json` for the continually evolving catalogue | e.g., `opus`, `sonnet`, `flash`, `pro`, `mistral` |
   | Custom | User-managed entries such as `llama3.2` | Define your own aliases per entry |
 
@@ -179,7 +179,7 @@ OPENAI_ALLOWED_MODELS=gpt-5.1-codex-mini,gpt-5-mini,o3-mini,o4-mini,mini
 GOOGLE_ALLOWED_MODELS=flash,pro
 
 # X.AI GROK model restrictions
-XAI_ALLOWED_MODELS=grok-3,grok-3-fast,grok-4
+XAI_ALLOWED_MODELS=grok-4-1-fast,grok-code-fast-1,grok-4-1-fast-non-reasoning,grok-4
 
 # OpenRouter model restrictions (affects models via custom provider)
 OPENROUTER_ALLOWED_MODELS=opus,sonnet,mistral
@@ -208,7 +208,7 @@ GOOGLE_ALLOWED_MODELS=pro
 # Balanced selection
 GOOGLE_ALLOWED_MODELS=flash,pro
 OPENAI_ALLOWED_MODELS=gpt-5.1-codex-mini,gpt-5-mini,o4-mini
-XAI_ALLOWED_MODELS=grok,grok-3-fast
+XAI_ALLOWED_MODELS=grok-4-1-fast,grok-code-fast-1,grok,grok-3-fast
 ```
 
 ### Advanced Configuration

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,7 @@ DEFAULT_MODEL=auto  # Claude picks best model for each task (recommended)
   |----------|-----------------|-----------------|
   | OpenAI | `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-mini`, `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-codex`, `gpt-4.1`, `o3`, `o3-mini`, `o3-pro`, `o4-mini` | `gpt5.1`, `gpt-5.1`, `5.1`, `gpt5.1-codex`, `codex-5.1`, `codex-mini`, `gpt5`, `gpt5pro`, `mini`, `nano`, `codex`, `o3mini`, `o3pro`, `o4mini` |
   | Gemini | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash`, `gemini-2.0-flash-lite` | `pro`, `gemini-pro`, `flash`, `flash-2.0`, `flashlite` |
-  | X.AI | `grok-4-1-fast`, `grok-4-1-fast-non-reasoning`, `grok-code-fast-1`, `grok-4`, `grok-3`, `grok-3-fast` | `grok-4-1-fast-reasoning`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`, `grok`, `grok4`, `grok3`, `grok3fast`, `grokfast` |
+  | X.AI | `grok-4-1-fast`, `grok-4-1-fast-non-reasoning`, `grok-4-fast`, `grok-4-fast-non-reasoning`, `grok-code-fast-1`, `grok-4`, `grok-3`, `grok-3-fast` | `grok-4-1-fast-reasoning`, `grok-4-1-fast-reasoning-latest`, `grok-4-fast-reasoning`, `grok-4-fast-reasoning-latest`, `grok4fast`, `grok-code-fast`, `grokcodefast`, `grok`, `grok4`, `grok3`, `grok3fast`, `grokfast` |
   | OpenRouter | See `conf/openrouter_models.json` for the continually evolving catalogue | e.g., `opus`, `sonnet`, `flash`, `pro`, `mistral` |
   | Custom | User-managed entries such as `llama3.2` | Define your own aliases per entry |
 
@@ -179,7 +179,7 @@ OPENAI_ALLOWED_MODELS=gpt-5.1-codex-mini,gpt-5-mini,o3-mini,o4-mini,mini
 GOOGLE_ALLOWED_MODELS=flash,pro
 
 # X.AI GROK model restrictions
-XAI_ALLOWED_MODELS=grok-4-1-fast,grok-code-fast-1,grok-4-1-fast-non-reasoning,grok-4
+XAI_ALLOWED_MODELS=grok-4-1-fast,grok-4-fast,grok-code-fast-1,grok-4-1-fast-non-reasoning,grok-4-fast-non-reasoning,grok-4
 
 # OpenRouter model restrictions (affects models via custom provider)
 OPENROUTER_ALLOWED_MODELS=opus,sonnet,mistral
@@ -208,7 +208,7 @@ GOOGLE_ALLOWED_MODELS=pro
 # Balanced selection
 GOOGLE_ALLOWED_MODELS=flash,pro
 OPENAI_ALLOWED_MODELS=gpt-5.1-codex-mini,gpt-5-mini,o4-mini
-XAI_ALLOWED_MODELS=grok-4-1-fast,grok-code-fast-1,grok,grok-3-fast
+XAI_ALLOWED_MODELS=grok-4-1-fast,grok-4-fast,grok-code-fast-1,grok,grok-3-fast
 ```
 
 ### Advanced Configuration

--- a/docs/custom_models.md
+++ b/docs/custom_models.md
@@ -64,6 +64,8 @@ The curated defaults in `conf/openrouter_models.json` include popular entries su
 | `gpt5.1`, `gpt-5.1`, `5.1` | `openai/gpt-5.1` | Flagship GPT-5.1 with reasoning and vision |
 | `gpt5.1-codex`, `codex-5.1` | `openai/gpt-5.1-codex` | Agentic coding specialization (Responses API) |
 | `codex-mini`, `gpt5.1-codex-mini` | `openai/gpt-5.1-codex-mini` | Cost-efficient Codex variant with streaming |
+| `grok-4-1-fast`, `grok-4-1-fast-reasoning` | `x-ai/grok-4-1-fast-reasoning` | Frontier multimodal model optimized for high-performance agentic tool calling with 2M context window |
+| `grok-code-fast`, `grokcodefast` | `x-ai/grok-code-fast-1` | Speedy reasoning model specialized for agentic coding |
 
 Consult the JSON file for the full list, aliases, and capability flags. Add new entries as OpenRouter releases additional models.
 
@@ -92,6 +94,18 @@ OpenAI's November 13, 2025 drop introduced `gpt-5.1`, `gpt-5.1-codex`, and `gpt-
 | `gpt-5.1-codex-mini` | Cost-efficient Codex variant | Streaming enabled, retains 400K context and code-generation flag |
 
 These entries include pricing-friendly aliases (`gpt5.1`, `codex-5.1`, `codex-mini`) plus updated capability flags (`supports_extended_thinking`, `allow_code_generation`). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
+
+### Latest xAI releases
+
+xAI's recent release introduced `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`, and `grok-code-fast-1`, all of which now ship in `conf/xai_models.json`:
+
+| Model | Highlights | Notes |
+|-------|------------|-------|
+| `grok-4-1-fast` | 2M context, frontier multimodal model optimized for high-performance agentic tool calling | Streaming enabled; exceptional token efficiency; function calling, structured outputs, and reasoning support; use for cost-conscious reasoning tasks |
+| `grok-4-1-fast-non-reasoning` | 2M context, ultra-fast text-to-text generation | No reasoning support; optimized for speed and stability; high-throughput tasks |
+| `grok-code-fast-1` | 256K context, specialized for agentic coding | Streaming enabled; `allow_code_generation=true`; optimized for coding workflows |
+
+These entries include convenient aliases (`grok-4-1-fast`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`) plus capability flags (`supports_extended_thinking`, `allow_code_generation`). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
 
 Because providers load the manifests on import, you can tweak capabilities without touching Python. Restart the server after editing the JSON files so changes are picked up.
 

--- a/docs/custom_models.md
+++ b/docs/custom_models.md
@@ -64,7 +64,7 @@ The curated defaults in `conf/openrouter_models.json` include popular entries su
 | `gpt5.1`, `gpt-5.1`, `5.1` | `openai/gpt-5.1` | Flagship GPT-5.1 with reasoning and vision |
 | `gpt5.1-codex`, `codex-5.1` | `openai/gpt-5.1-codex` | Agentic coding specialization (Responses API) |
 | `codex-mini`, `gpt5.1-codex-mini` | `openai/gpt-5.1-codex-mini` | Cost-efficient Codex variant with streaming |
-| `grok-4-1-fast`, `grok-4-1-fast-reasoning` | `x-ai/grok-4.1-fast` | Frontier multimodal model optimized for high-performance agentic tool calling with 2M context window |
+| `grok`, `grok-4-1-fast`, `grok-4-1-fast-reasoning` | `x-ai/grok-4.1-fast` | Frontier multimodal model optimized for high-performance agentic tool calling with 2M context window |
 | `grok-code-fast`, `grokcodefast` | `x-ai/grok-code-fast-1` | Speedy reasoning model specialized for agentic coding |
 
 Consult the JSON file for the full list, aliases, and capability flags. Add new entries as OpenRouter releases additional models.
@@ -105,7 +105,7 @@ xAI's recent release introduced `grok-4-1-fast`, `grok-4-1-fast-non-reasoning`, 
 | `grok-4-1-fast-non-reasoning` | 2M context, ultra-fast text-to-text generation | No reasoning support; optimized for speed and stability; high-throughput tasks |
 | `grok-code-fast-1` | 256K context, specialized for agentic coding | Streaming enabled; `allow_code_generation=true`; optimized for coding workflows |
 
-These entries include convenient aliases (`grok-4-1-fast-reasoning`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`) plus capability flags (`supports_extended_thinking`, `allow_code_generation`). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
+These entries include convenient aliases (`grok`, `grok-4-1-fast-reasoning`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`) plus capability flags (`supports_extended_thinking`, `allow_code_generation`). Note that the `grok` alias now resolves to `grok-4-1-fast` (the latest flagship model). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
 
 Because providers load the manifests on import, you can tweak capabilities without touching Python. Restart the server after editing the JSON files so changes are picked up.
 

--- a/docs/custom_models.md
+++ b/docs/custom_models.md
@@ -64,7 +64,7 @@ The curated defaults in `conf/openrouter_models.json` include popular entries su
 | `gpt5.1`, `gpt-5.1`, `5.1` | `openai/gpt-5.1` | Flagship GPT-5.1 with reasoning and vision |
 | `gpt5.1-codex`, `codex-5.1` | `openai/gpt-5.1-codex` | Agentic coding specialization (Responses API) |
 | `codex-mini`, `gpt5.1-codex-mini` | `openai/gpt-5.1-codex-mini` | Cost-efficient Codex variant with streaming |
-| `grok-4-1-fast`, `grok-4-1-fast-reasoning` | `x-ai/grok-4-1-fast-reasoning` | Frontier multimodal model optimized for high-performance agentic tool calling with 2M context window |
+| `grok-4-1-fast`, `grok-4-1-fast-reasoning` | `x-ai/grok-4.1-fast` | Frontier multimodal model optimized for high-performance agentic tool calling with 2M context window |
 | `grok-code-fast`, `grokcodefast` | `x-ai/grok-code-fast-1` | Speedy reasoning model specialized for agentic coding |
 
 Consult the JSON file for the full list, aliases, and capability flags. Add new entries as OpenRouter releases additional models.
@@ -97,7 +97,7 @@ These entries include pricing-friendly aliases (`gpt5.1`, `codex-5.1`, `codex-mi
 
 ### Latest xAI releases
 
-xAI's recent release introduced `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-reasoning`, and `grok-code-fast-1`, all of which now ship in `conf/xai_models.json`:
+xAI's recent release introduced `grok-4-1-fast`, `grok-4-1-fast-non-reasoning`, and `grok-code-fast-1`, all of which now ship in `conf/xai_models.json`:
 
 | Model | Highlights | Notes |
 |-------|------------|-------|
@@ -105,7 +105,7 @@ xAI's recent release introduced `grok-4-1-fast-reasoning`, `grok-4-1-fast-non-re
 | `grok-4-1-fast-non-reasoning` | 2M context, ultra-fast text-to-text generation | No reasoning support; optimized for speed and stability; high-throughput tasks |
 | `grok-code-fast-1` | 256K context, specialized for agentic coding | Streaming enabled; `allow_code_generation=true`; optimized for coding workflows |
 
-These entries include convenient aliases (`grok-4-1-fast`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`) plus capability flags (`supports_extended_thinking`, `allow_code_generation`). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
+These entries include convenient aliases (`grok-4-1-fast-reasoning`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`) plus capability flags (`supports_extended_thinking`, `allow_code_generation`). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
 
 Because providers load the manifests on import, you can tweak capabilities without touching Python. Restart the server after editing the JSON files so changes are picked up.
 

--- a/docs/custom_models.md
+++ b/docs/custom_models.md
@@ -11,22 +11,26 @@ This guide covers setting up multiple AI model providers including OpenRouter, c
 ## When to Use What
 
 **Use OpenRouter when you want:**
+
 - Access to models not available through native APIs (GPT-4, Claude, Mistral, etc.)
 - Simplified billing across multiple model providers
 - Experimentation with various models without separate API keys
 
 **Use Custom URLs for:**
+
 - **Local models** like Ollama (Llama, Mistral, etc.)
 - **Self-hosted inference** with vLLM, LM Studio, text-generation-webui
 - **Private/enterprise APIs** that use OpenAI-compatible format
 - **Cost control** with local hardware
 
 **Use native APIs (Gemini/OpenAI) when you want:**
+
 - Direct access to specific providers without intermediary
 - Potentially lower latency and costs
 - Access to the latest model features immediately upon release
 
 **Mix & Match:** You can use multiple providers simultaneously! For example:
+
 - OpenRouter for expensive commercial models (GPT-4, Claude)
 - Custom URLs for local models (Ollama Llama)
 - Native APIs for specific providers (Gemini Pro with extended thinking)
@@ -50,30 +54,30 @@ Copy whichever file you need into your project (or point the corresponding `*_MO
 
 The curated defaults in `conf/openrouter_models.json` include popular entries such as:
 
-| Alias | Canonical Model | Highlights |
-|-------|-----------------|------------|
-| `opus`, `claude-opus` | `anthropic/claude-opus-4.1` | Flagship Claude reasoning model with vision |
-| `sonnet`, `sonnet4.5` | `anthropic/claude-sonnet-4.5` | Balanced Claude with high context window |
-| `haiku` | `anthropic/claude-3.5-haiku` | Fast Claude option with vision |
-| `pro`, `gemini` | `google/gemini-2.5-pro` | Frontier Gemini with extended thinking |
-| `flash` | `google/gemini-2.5-flash` | Ultra-fast Gemini with vision |
-| `mistral` | `mistralai/mistral-large-2411` | Frontier Mistral (text only) |
-| `llama3` | `meta-llama/llama-3-70b` | Large open-weight text model |
-| `deepseek-r1` | `deepseek/deepseek-r1-0528` | DeepSeek reasoning model |
-| `perplexity` | `perplexity/llama-3-sonar-large-32k-online` | Search-augmented model |
-| `gpt5.1`, `gpt-5.1`, `5.1` | `openai/gpt-5.1` | Flagship GPT-5.1 with reasoning and vision |
-| `gpt5.1-codex`, `codex-5.1` | `openai/gpt-5.1-codex` | Agentic coding specialization (Responses API) |
-| `codex-mini`, `gpt5.1-codex-mini` | `openai/gpt-5.1-codex-mini` | Cost-efficient Codex variant with streaming |
-| `grok`, `grok-4-1-fast`, `grok-4-1-fast-reasoning` | `x-ai/grok-4.1-fast` | Frontier multimodal model optimized for high-performance agentic tool calling with 2M context window |
-| `grok-code-fast`, `grokcodefast` | `x-ai/grok-code-fast-1` | Speedy reasoning model specialized for agentic coding |
+| Alias                                              | Canonical Model                             | Highlights                                                                                           |
+| -------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `opus`, `claude-opus`                              | `anthropic/claude-opus-4.1`                 | Flagship Claude reasoning model with vision                                                          |
+| `sonnet`, `sonnet4.5`                              | `anthropic/claude-sonnet-4.5`               | Balanced Claude with high context window                                                             |
+| `haiku`                                            | `anthropic/claude-3.5-haiku`                | Fast Claude option with vision                                                                       |
+| `pro`, `gemini`                                    | `google/gemini-2.5-pro`                     | Frontier Gemini with extended thinking                                                               |
+| `flash`                                            | `google/gemini-2.5-flash`                   | Ultra-fast Gemini with vision                                                                        |
+| `mistral`                                          | `mistralai/mistral-large-2411`              | Frontier Mistral (text only)                                                                         |
+| `llama3`                                           | `meta-llama/llama-3-70b`                    | Large open-weight text model                                                                         |
+| `deepseek-r1`                                      | `deepseek/deepseek-r1-0528`                 | DeepSeek reasoning model                                                                             |
+| `perplexity`                                       | `perplexity/llama-3-sonar-large-32k-online` | Search-augmented model                                                                               |
+| `gpt5.1`, `gpt-5.1`, `5.1`                         | `openai/gpt-5.1`                            | Flagship GPT-5.1 with reasoning and vision                                                           |
+| `gpt5.1-codex`, `codex-5.1`                        | `openai/gpt-5.1-codex`                      | Agentic coding specialization (Responses API)                                                        |
+| `codex-mini`, `gpt5.1-codex-mini`                  | `openai/gpt-5.1-codex-mini`                 | Cost-efficient Codex variant with streaming                                                          |
+| `grok`, `grok-4-1-fast`, `grok-4-1-fast-reasoning` | `x-ai/grok-4.1-fast`                        | Frontier multimodal model optimized for high-performance agentic tool calling with 2M context window |
+| `grok-code-fast`, `grokcodefast`                   | `x-ai/grok-code-fast-1`                     | Speedy reasoning model specialized for agentic coding                                                |
 
 Consult the JSON file for the full list, aliases, and capability flags. Add new entries as OpenRouter releases additional models.
 
 ### Custom/Local Models
 
-| Alias | Maps to Local Model | Note |
-|-------|-------------------|------|
-| `local-llama`, `local` | `llama3.2` | Requires `CUSTOM_API_URL` configured |
+| Alias                  | Maps to Local Model | Note                                 |
+| ---------------------- | ------------------- | ------------------------------------ |
+| `local-llama`, `local` | `llama3.2`          | Requires `CUSTOM_API_URL` configured |
 
 View the baseline OpenRouter catalogue in [`conf/openrouter_models.json`](conf/openrouter_models.json) and populate [`conf/custom_models.json`](conf/custom_models.json) with your local models.
 
@@ -87,25 +91,34 @@ Native catalogues (`conf/openai_models.json`, `conf/gemini_models.json`, `conf/x
 
 OpenAI's November 13, 2025 drop introduced `gpt-5.1`, `gpt-5.1-codex`, and `gpt-5.1-codex-mini`, all of which now ship in `conf/openai_models.json`:
 
-| Model | Highlights | Notes |
-|-------|------------|-------|
-| `gpt-5.1` | 400K context, 128K output, multimodal IO, configurable reasoning effort | Streaming enabled; use for balanced agent/coding flows |
-| `gpt-5.1-codex` | Responses-only agentic coding version of GPT-5.1 | Streaming disabled; `use_openai_response_api=true`; `allow_code_generation=true` |
-| `gpt-5.1-codex-mini` | Cost-efficient Codex variant | Streaming enabled, retains 400K context and code-generation flag |
+| Model                | Highlights                                                              | Notes                                                                            |
+| -------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `gpt-5.1`            | 400K context, 128K output, multimodal IO, configurable reasoning effort | Streaming enabled; use for balanced agent/coding flows                           |
+| `gpt-5.1-codex`      | Responses-only agentic coding version of GPT-5.1                        | Streaming disabled; `use_openai_response_api=true`; `allow_code_generation=true` |
+| `gpt-5.1-codex-mini` | Cost-efficient Codex variant                                            | Streaming enabled, retains 400K context and code-generation flag                 |
 
 These entries include pricing-friendly aliases (`gpt5.1`, `codex-5.1`, `codex-mini`) plus updated capability flags (`supports_extended_thinking`, `allow_code_generation`). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
 
 ### Latest xAI releases
 
-xAI's recent release introduced `grok-4-1-fast`, `grok-4-1-fast-non-reasoning`, and `grok-code-fast-1`, all of which now ship in `conf/xai_models.json`:
+xAI has released two model families in `conf/xai_models.json`:
 
-| Model | Highlights | Notes |
-|-------|------------|-------|
-| `grok-4-1-fast` | 2M context, frontier multimodal model optimized for high-performance agentic tool calling | Streaming enabled; exceptional token efficiency; function calling, structured outputs, and reasoning support; use for cost-conscious reasoning tasks |
-| `grok-4-1-fast-non-reasoning` | 2M context, ultra-fast text-to-text generation | No reasoning support; optimized for speed and stability; high-throughput tasks |
-| `grok-code-fast-1` | 256K context, specialized for agentic coding | Streaming enabled; `allow_code_generation=true`; optimized for coding workflows |
+**Grok 4.1 Fast Series (November 2025):**
 
-These entries include convenient aliases (`grok`, `grok-4-1-fast-reasoning`, `grok-4-1-fast-reasoning-latest`, `grok-code-fast`, `grokcodefast`) plus capability flags (`supports_extended_thinking`, `allow_code_generation`). Note that the `grok` alias now resolves to `grok-4-1-fast` (the latest flagship model). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
+| Model                         | Highlights                                                                                | Notes                                                                                                                                                |
+| ----------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `grok-4-1-fast`               | 2M context, frontier multimodal model optimized for high-performance agentic tool calling | Streaming enabled; exceptional token efficiency; function calling, structured outputs, and reasoning support; use for cost-conscious reasoning tasks |
+| `grok-4-1-fast-non-reasoning` | 2M context, ultra-fast text-to-text generation                                            | No reasoning support; optimized for speed and stability; high-throughput tasks                                                                       |
+| `grok-code-fast-1`            | 256K context, specialized for agentic coding                                              | Streaming enabled; `allow_code_generation=true`; optimized for coding workflows                                                                      |
+
+**Grok 4 Fast Series (September 2025):**
+
+| Model                       | Highlights                                          | Notes                                                                                        |
+| --------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `grok-4-fast`               | 2M context, cost-efficient frontier reasoning model | 98% lower cost vs Grok 4; comparable benchmark performance; reasoning and multimodal support |
+| `grok-4-fast-non-reasoning` | 2M context, ultra-low latency text generation       | No reasoning support; optimized for speed; text-only                                         |
+
+These entries include convenient aliases (`grok`, `grok-4-1-fast-reasoning`, `grok-4-1-fast-reasoning-latest`, `grok-4-fast-reasoning`, `grok-4-fast-reasoning-latest`, `grok4fast`, `grok-code-fast`, `grokcodefast`) plus capability flags (`supports_extended_thinking`, `allow_code_generation`). Note that the `grok` alias resolves to `grok-4-1-fast` (the latest flagship model). Copy the manifest if you operate custom deployment names so downstream providers inherit the same metadata.
 
 Because providers load the manifests on import, you can tweak capabilities without touching Python. Restart the server after editing the JSON files so changes are picked up.
 
@@ -120,17 +133,19 @@ heuristic described there).
 ### Option 1: OpenRouter Setup
 
 #### 1. Get API Key
+
 1. Sign up at [openrouter.ai](https://openrouter.ai/)
 2. Create an API key from your dashboard
 3. Add credits to your account
 
 #### 2. Set Environment Variable
+
 ```bash
 # Add to your .env file
 OPENROUTER_API_KEY=your-openrouter-api-key
 ```
 
-> **Note:** Control which models can be used directly in your OpenRouter dashboard at [openrouter.ai](https://openrouter.ai/). 
+> **Note:** Control which models can be used directly in your OpenRouter dashboard at [openrouter.ai](https://openrouter.ai/).
 > This gives you centralized control over model access and spending limits.
 
 That's it! The setup script handles all necessary configuration automatically.
@@ -140,6 +155,7 @@ That's it! The setup script handles all necessary configuration automatically.
 For local models like Ollama, vLLM, LM Studio, or any OpenAI-compatible API:
 
 #### 1. Start Your Local Model Server
+
 ```bash
 # Example: Ollama
 ollama serve
@@ -153,6 +169,7 @@ python -m vllm.entrypoints.openai.api_server --model meta-llama/Llama-2-7b-chat-
 ```
 
 #### 2. Configure Environment Variables
+
 ```bash
 # Add to your .env file
 CUSTOM_API_URL=http://localhost:11434/v1  # Ollama example
@@ -172,6 +189,7 @@ CUSTOM_API_URL=http://localhost:11434/v1  # Ollama default port
 #### 3. Examples for Different Platforms
 
 **Ollama:**
+
 ```bash
 CUSTOM_API_URL=http://localhost:11434/v1
 CUSTOM_API_KEY=
@@ -179,6 +197,7 @@ CUSTOM_MODEL_NAME=llama3.2
 ```
 
 **vLLM:**
+
 ```bash
 CUSTOM_API_URL=http://localhost:8000/v1
 CUSTOM_API_KEY=
@@ -186,6 +205,7 @@ CUSTOM_MODEL_NAME=meta-llama/Llama-2-7b-chat-hf
 ```
 
 **LM Studio:**
+
 ```bash
 CUSTOM_API_URL=http://localhost:1234/v1
 CUSTOM_API_KEY=lm-studio  # Or any value, LM Studio often requires some key
@@ -193,6 +213,7 @@ CUSTOM_MODEL_NAME=local-model
 ```
 
 **text-generation-webui (with OpenAI extension):**
+
 ```bash
 CUSTOM_API_URL=http://localhost:5001/v1
 CUSTOM_API_KEY=
@@ -202,6 +223,7 @@ CUSTOM_MODEL_NAME=your-loaded-model
 ## Using Models
 
 **Using model aliases (from the registry files):**
+
 ```
 # OpenRouter models:
 "Use opus for deep analysis"         # → anthropic/claude-opus-4
@@ -216,6 +238,7 @@ CUSTOM_MODEL_NAME=your-loaded-model
 ```
 
 **Using full model names:**
+
 ```
 # OpenRouter models:
 "Use anthropic/claude-opus-4 via zen for deep analysis"
@@ -239,8 +262,9 @@ The system automatically routes models to the appropriate provider:
 3. **Unknown models** → Fallback logic based on model name patterns
 
 **Provider Priority Order:**
+
 1. Native APIs (Google, OpenAI) - if API keys are available
-2. Custom endpoints - for models declared in `conf/custom_models.json`  
+2. Custom endpoints - for models declared in `conf/custom_models.json`
 3. OpenRouter - catch-all for cloud models
 
 This ensures clean separation between local and cloud models while maintaining flexibility for unknown models.
@@ -286,6 +310,7 @@ Edit `conf/openrouter_models.json` to tweak OpenRouter behaviour or `conf/custom
 ```
 
 **Field explanations:**
+
 - `model_name`: The model identifier (OpenRouter format like `vendor/model` or local name like `llama3.2`)
 - `aliases`: Array of short names users can type instead of the full model name
 - `context_window`: Total tokens the model can process (input + output combined)
@@ -299,6 +324,7 @@ Edit `conf/openrouter_models.json` to tweak OpenRouter behaviour or `conf/custom
 ## Available Models
 
 Popular models available through OpenRouter:
+
 - **GPT-4** - OpenAI's most capable model
 - **Claude 4** - Anthropic's models (Opus, Sonnet, Haiku)
 - **Mistral** - Including Mistral Large

--- a/docs/model_ranking.md
+++ b/docs/model_ranking.md
@@ -37,14 +37,14 @@ of the work so you can enforce organisational preferences easily.
 
 A straightforward rubric that mirrors typical provider tiers:
 
-| Intelligence | Guidance                                                                                  |
-|--------------|-------------------------------------------------------------------------------------------|
-| 18–19 | Frontier reasoning models (Gemini 3.0 Pro, Gemini 2.5 Pro, GPT‑5.1 Codex, GPT‑5.1, GPT‑5) |
-| 15–17 | Strong general models with large context (O3 Pro, DeepSeek R1)                            |
-| 12–14 | Balanced assistants (Claude Opus/Sonnet, Mistral Large)                                   |
-| 9–11  | Fast distillations (Gemini Flash, GPT-5 Mini, Mistral medium)                             |
-| 6–8   | Local or efficiency-focused models (Llama 3 70B, Claude Haiku)                            |
-| ≤5    | Experimental/lightweight models                                                           |
+| Intelligence | Guidance |
+|--------------|----------|
+| 18–19 | Frontier reasoning models (Gemini 3.0 Pro, Gemini 2.5 Pro, GPT‑5.1 Codex, GPT‑5.1, GPT‑5, GPT-5-Pro) |
+| 15–17 | Strong general models with large context (Grok-4, Grok-4.1 Fast, O3 Pro, DeepSeek R1) |
+| 12–14 | Balanced assistants (Grok Code Fast 1, Grok-4.1 Fast Non-Reasoning, Claude Opus/Sonnet, Mistral Large) |
+| 9–11  | Fast distillations (Grok-3 Fast, Gemini Flash, GPT-5 Mini, Mistral medium) |
+| 6–8   | Local or efficiency-focused models (Llama 3 70B, Claude Haiku) |
+| ≤5    | Experimental/lightweight models |
 
 Record the reasoning for your scores so future updates stay consistent.
 

--- a/docs/model_ranking.md
+++ b/docs/model_ranking.md
@@ -40,8 +40,8 @@ A straightforward rubric that mirrors typical provider tiers:
 | Intelligence | Guidance |
 |--------------|----------|
 | 18–19 | Frontier reasoning models (Gemini 3.0 Pro, Gemini 2.5 Pro, GPT‑5.1 Codex, GPT‑5.1, GPT‑5, GPT-5-Pro) |
-| 15–17 | Strong general models with large context (Grok-4, Grok-4.1 Fast, O3 Pro, DeepSeek R1) |
-| 12–14 | Balanced assistants (Grok Code Fast 1, Grok-4.1 Fast Non-Reasoning, Claude Opus/Sonnet, Mistral Large) |
+| 15–17 | Strong general models with large context (Grok-4, Grok-4.1 Fast, Grok 4 Fast, O3 Pro, DeepSeek R1) |
+| 12–14 | Balanced assistants (Grok Code Fast 1, Grok-4.1 Fast Non-Reasoning, Grok 4 Fast Non-Reasoning, Claude Opus/Sonnet, Mistral Large) |
 | 9–11  | Fast distillations (Grok-3 Fast, Gemini Flash, GPT-5 Mini, Mistral medium) |
 | 6–8   | Local or efficiency-focused models (Llama 3 70B, Claude Haiku) |
 | ≤5    | Experimental/lightweight models |

--- a/docs/tools/analyze.md
+++ b/docs/tools/analyze.md
@@ -64,7 +64,7 @@ This workflow ensures methodical analysis before expert insights, resulting in d
 
 **Initial Configuration (used in step 1):**
 - `prompt`: What to analyze or look for (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `analysis_type`: architecture|performance|security|quality|general (default: general)
 - `output_format`: summary|detailed|actionable (default: detailed)
 - `temperature`: Temperature for analysis (0-1, default 0.2)

--- a/docs/tools/chat.md
+++ b/docs/tools/chat.md
@@ -52,7 +52,7 @@ word verdict in the end.
 ## Tool Parameters
 
 - `prompt`: Your question or discussion topic (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `absolute_file_paths`: Optional absolute file or directory paths for additional context
 - `images`: Optional images for visual context (absolute paths)
 - `working_directory_absolute_path`: **Required** - Absolute path to an existing directory where generated code artifacts will be saved

--- a/docs/tools/codereview.md
+++ b/docs/tools/codereview.md
@@ -79,7 +79,7 @@ The above prompt will simultaneously run two separate `codereview` tools with tw
 
 **Initial Review Configuration (used in step 1):**
 - `prompt`: User's summary of what the code does, expected behavior, constraints, and review objectives (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `review_type`: full|security|performance|quick (default: full)
 - `focus_on`: Specific aspects to focus on (e.g., "security vulnerabilities", "performance bottlenecks")
 - `standards`: Coding standards to enforce (e.g., "PEP8", "ESLint", "Google Style Guide")

--- a/docs/tools/debug.md
+++ b/docs/tools/debug.md
@@ -72,7 +72,7 @@ This structured approach ensures Claude performs methodical groundwork before ex
 - `images`: Visual debugging materials (error screenshots, logs, etc.)
 
 **Model Selection:**
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)
 - `use_assistant_model`: Whether to use expert analysis phase (default: true, set to false to use Claude only)
 

--- a/docs/tools/precommit.md
+++ b/docs/tools/precommit.md
@@ -140,7 +140,7 @@ Use zen and perform a thorough precommit ensuring there aren't any new regressio
 **Initial Configuration (used in step 1):**
 - `path`: Starting directory to search for repos (REQUIRED for step 1, must be absolute path)
 - `prompt`: The original user request description for the changes (required for context)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `compare_to`: Compare against a branch/tag instead of local changes (optional)
 - `severity_filter`: critical|high|medium|low|all (default: all)
 - `include_staged`: Include staged changes in the review (default: true)

--- a/docs/tools/refactor.md
+++ b/docs/tools/refactor.md
@@ -102,7 +102,7 @@ This results in Claude first performing its own expert analysis, encouraging it 
 **Initial Configuration (used in step 1):**
 - `prompt`: Description of refactoring goals, context, and specific areas of focus (required)
 - `refactor_type`: codesmells|decompose|modernize|organization (default: codesmells)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `focus_areas`: Specific areas to focus on (e.g., 'performance', 'readability', 'maintainability', 'security')
 - `style_guide_examples`: Optional existing code files to use as style/pattern reference (absolute paths)
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)

--- a/docs/tools/secaudit.md
+++ b/docs/tools/secaudit.md
@@ -85,7 +85,7 @@ security remediation plan using planner
 - `images`: Architecture diagrams, security documentation, or visual references
 
 **Initial Security Configuration (used in step 1):**
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `security_scope`: Application context, technology stack, and security boundary definition (required)
 - `threat_level`: low|medium|high|critical (default: medium) - determines assessment depth and urgency
 - `compliance_requirements`: List of compliance frameworks to assess against (e.g., ["PCI DSS", "SOC2"])

--- a/docs/tools/testgen.md
+++ b/docs/tools/testgen.md
@@ -69,7 +69,7 @@ Test generation excels with extended reasoning models like Gemini Pro or O3, whi
 
 **Initial Configuration (used in step 1):**
 - `prompt`: Description of what to test, testing objectives, and specific scope/focus areas (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `test_examples`: Optional existing test files or directories to use as style/pattern reference (absolute paths)
 - `thinking_mode`: minimal|low|medium|high|max (default: medium, Gemini only)
 - `use_assistant_model`: Whether to use expert test generation phase (default: true, set to false to use Claude only)

--- a/docs/tools/thinkdeep.md
+++ b/docs/tools/thinkdeep.md
@@ -30,7 +30,7 @@ with the best architecture for my project
 ## Tool Parameters
 
 - `prompt`: Your current thinking/analysis to extend and validate (required)
-- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano (default: server default)
+- `model`: auto|pro|flash|flash-2.0|flashlite|o3|o3-mini|o4-mini|gpt4.1|gpt5.1|gpt5.1-codex|gpt5.1-codex-mini|gpt5|gpt5-mini|gpt5-nano|grok-4-1-fast|grok-4-1-fast-non-reasoning|grok-code-fast-1|grok-4|grok-3|grok-3-fast (default: server default)
 - `problem_context`: Additional context about the problem or goal
 - `focus_areas`: Specific aspects to focus on (architecture, performance, security, etc.)
 - `files`: Optional file paths or directories for additional context (absolute paths)

--- a/providers/xai.py
+++ b/providers/xai.py
@@ -53,34 +53,51 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
         if not allowed_models:
             return None
 
+        # Helper to find first available from preference list
+        def find_first(preferences: list[str]) -> Optional[str]:
+            """Return first available model from preference list."""
+            for model in preferences:
+                if model in allowed_models:
+                    return model
+            return None
+
         if category == ToolModelCategory.EXTENDED_REASONING:
-            # Prefer GROK-4 for advanced reasoning with thinking mode
-            if "grok-4" in allowed_models:
-                return "grok-4"
-            elif "grok-3" in allowed_models:
-                return "grok-3"
-            # Fall back to any available model
-            return allowed_models[0]
+            # Prefer GROK-4 Fast for cost-efficient reasoning, then GROK-4
+            preferred = find_first(
+                [
+                    "grok-4-fast",
+                    "grok-4",
+                    "grok-code-fast-1",
+                    "grok-3",
+                ]
+            )
+            return preferred if preferred else allowed_models[0]
 
         elif category == ToolModelCategory.FAST_RESPONSE:
-            # Prefer GROK-3-Fast for speed, then GROK-4
-            if "grok-3-fast" in allowed_models:
-                return "grok-3-fast"
-            elif "grok-4" in allowed_models:
-                return "grok-4"
-            # Fall back to any available model
-            return allowed_models[0]
+            # Prefer GROK-4 Fast Non-Reasoning for speed, then GROK-3-Fast
+            preferred = find_first(
+                [
+                    "grok-4-fast-non-reasoning",
+                    "grok-3-fast",
+                    "grok-4-fast",
+                    "grok-code-fast-1",
+                    "grok-4",
+                ]
+            )
+            return preferred if preferred else allowed_models[0]
 
         else:  # BALANCED or default
-            # Prefer GROK-4 for balanced use (best overall capabilities)
-            if "grok-4" in allowed_models:
-                return "grok-4"
-            elif "grok-3" in allowed_models:
-                return "grok-3"
-            elif "grok-3-fast" in allowed_models:
-                return "grok-3-fast"
-            # Fall back to any available model
-            return allowed_models[0]
+            # Prefer GROK-4 Fast for balanced use (cost-efficient with reasoning)
+            preferred = find_first(
+                [
+                    "grok-4-fast",
+                    "grok-code-fast-1",
+                    "grok-4",
+                    "grok-3",
+                    "grok-3-fast",
+                ]
+            )
+            return preferred if preferred else allowed_models[0]
 
 
 # Load registry data at import time

--- a/providers/xai.py
+++ b/providers/xai.py
@@ -62,10 +62,10 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
             return None
 
         if category == ToolModelCategory.EXTENDED_REASONING:
-            # Prefer GROK-4 Fast for cost-efficient reasoning, then GROK-4
+            # Prefer GROK-4.1 Fast Reasoning for cost-efficient reasoning, then GROK-4
             preferred = find_first(
                 [
-                    "grok-4-fast",
+                    "grok-4-1-fast",
                     "grok-4",
                     "grok-code-fast-1",
                     "grok-3",
@@ -74,12 +74,12 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
             return preferred if preferred else allowed_models[0]
 
         elif category == ToolModelCategory.FAST_RESPONSE:
-            # Prefer GROK-4 Fast Non-Reasoning for speed, then GROK-3-Fast
+            # Prefer GROK-4.1 Fast Non-Reasoning for speed, then GROK-3-Fast
             preferred = find_first(
                 [
-                    "grok-4-fast-non-reasoning",
+                    "grok-4-1-fast-non-reasoning",
+                    "grok-4-1-fast",
                     "grok-3-fast",
-                    "grok-4-fast",
                     "grok-code-fast-1",
                     "grok-4",
                 ]
@@ -87,10 +87,10 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
             return preferred if preferred else allowed_models[0]
 
         else:  # BALANCED or default
-            # Prefer GROK-4 Fast for balanced use (cost-efficient with reasoning)
+            # Prefer GROK-4.1 Fast Reasoning for balanced use (cost-efficient with reasoning)
             preferred = find_first(
                 [
-                    "grok-4-fast",
+                    "grok-4-1-fast",
                     "grok-code-fast-1",
                     "grok-4",
                     "grok-3",

--- a/providers/xai.py
+++ b/providers/xai.py
@@ -62,10 +62,11 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
             return None
 
         if category == ToolModelCategory.EXTENDED_REASONING:
-            # Prefer GROK-4.1 Fast Reasoning for cost-efficient reasoning, then GROK-4
+            # Prefer GROK-4.1 Fast Reasoning for cost-efficient reasoning, then GROK-4 Fast, then GROK-4
             preferred = find_first(
                 [
                     "grok-4-1-fast",
+                    "grok-4-fast",
                     "grok-4",
                     "grok-code-fast-1",
                     "grok-3",
@@ -74,11 +75,13 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
             return preferred if preferred else allowed_models[0]
 
         elif category == ToolModelCategory.FAST_RESPONSE:
-            # Prefer GROK-4.1 Fast Non-Reasoning for speed, then GROK-3-Fast
+            # Prefer GROK-4.1 Fast Non-Reasoning for speed, then GROK-4 Fast Non-Reasoning, then GROK-3-Fast
             preferred = find_first(
                 [
                     "grok-4-1-fast-non-reasoning",
+                    "grok-4-fast-non-reasoning",
                     "grok-4-1-fast",
+                    "grok-4-fast",
                     "grok-3-fast",
                     "grok-code-fast-1",
                     "grok-4",
@@ -91,6 +94,7 @@ class XAIModelProvider(RegistryBackedProviderMixin, OpenAICompatibleProvider):
             preferred = find_first(
                 [
                     "grok-4-1-fast",
+                    "grok-4-fast",
                     "grok-code-fast-1",
                     "grok-4",
                     "grok-3",

--- a/tests/test_auto_mode_comprehensive.py
+++ b/tests/test_auto_mode_comprehensive.py
@@ -108,9 +108,9 @@ class TestAutoModeComprehensive:
                     "OPENROUTER_API_KEY": None,
                 },
                 {
-                    "EXTENDED_REASONING": "grok-4",  # GROK-4 for reasoning (now preferred)
-                    "FAST_RESPONSE": "grok-3-fast",  # GROK-3-fast for speed
-                    "BALANCED": "grok-4",  # GROK-4 as balanced (now preferred)
+                    "EXTENDED_REASONING": "grok-4-1-fast",  # GROK-4.1 Fast Reasoning for cost-efficient reasoning
+                    "FAST_RESPONSE": "grok-4-1-fast-non-reasoning",  # GROK-4.1 Fast Non-Reasoning for speed
+                    "BALANCED": "grok-4-1-fast",  # GROK-4.1 Fast Reasoning as balanced (cost-efficient with reasoning)
                 },
             ),
             # Both Gemini and OpenAI available - Google comes first in priority
@@ -190,7 +190,10 @@ class TestAutoModeComprehensive:
         "tool_class,expected_category",
         [
             (ChatTool, ToolModelCategory.FAST_RESPONSE),
-            (AnalyzeTool, ToolModelCategory.EXTENDED_REASONING),  # AnalyzeTool uses EXTENDED_REASONING
+            (
+                AnalyzeTool,
+                ToolModelCategory.EXTENDED_REASONING,
+            ),  # AnalyzeTool uses EXTENDED_REASONING
             (DebugIssueTool, ToolModelCategory.EXTENDED_REASONING),
             (ThinkDeepTool, ToolModelCategory.EXTENDED_REASONING),
         ],
@@ -533,12 +536,20 @@ class TestAutoModeComprehensive:
             mock_provider._resolve_model_name = lambda alias: ("gemini-2.5-flash" if alias == "flash" else alias)
             mock_provider.generate_content.return_value = mock_response
 
-            with patch.object(ModelProviderRegistry, "get_provider_for_model", return_value=mock_provider):
+            with patch.object(
+                ModelProviderRegistry,
+                "get_provider_for_model",
+                return_value=mock_provider,
+            ):
                 chat_tool = ChatTool()
                 workdir = tmp_path / "chat_artifacts"
                 workdir.mkdir(parents=True, exist_ok=True)
                 result = await chat_tool.execute(
-                    {"prompt": "test", "model": "flash", "working_directory_absolute_path": str(workdir)}
+                    {
+                        "prompt": "test",
+                        "model": "flash",
+                        "working_directory_absolute_path": str(workdir),
+                    }
                 )  # Use alias in auto mode
 
                 # Should succeed with proper model resolution

--- a/tests/test_auto_mode_provider_selection.py
+++ b/tests/test_auto_mode_provider_selection.py
@@ -37,7 +37,12 @@ class TestAutoModeProviderSelection:
 
         # Save original environment
         original_env = {}
-        for key in ["GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY"]:
+        for key in [
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ]:
             original_env[key] = os.environ.get(key)
 
         try:
@@ -59,7 +64,11 @@ class TestAutoModeProviderSelection:
             balanced = ModelProviderRegistry.get_preferred_fallback_model(ToolModelCategory.BALANCED)
 
             # Should select appropriate Gemini models
-            assert extended_reasoning in ["gemini-3-pro-preview", "gemini-2.5-pro", "pro"]
+            assert extended_reasoning in [
+                "gemini-3-pro-preview",
+                "gemini-2.5-pro",
+                "pro",
+            ]
             assert fast_response in ["gemini-2.5-flash", "flash"]
             assert balanced in ["gemini-2.5-flash", "flash"]
 
@@ -76,7 +85,12 @@ class TestAutoModeProviderSelection:
 
         # Save original environment
         original_env = {}
-        for key in ["GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY"]:
+        for key in [
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ]:
             original_env[key] = os.environ.get(key)
 
         try:
@@ -115,7 +129,12 @@ class TestAutoModeProviderSelection:
 
         # Save original environment
         original_env = {}
-        for key in ["GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY"]:
+        for key in [
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ]:
             original_env[key] = os.environ.get(key)
 
         try:
@@ -157,7 +176,12 @@ class TestAutoModeProviderSelection:
 
         # Save original environment
         original_env = {}
-        for key in ["GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY"]:
+        for key in [
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ]:
             original_env[key] = os.environ.get(key)
 
         try:
@@ -317,10 +341,18 @@ class TestAutoModeProviderSelection:
             # Test that providers resolve aliases correctly
             test_cases = [
                 ("flash", ProviderType.GOOGLE, "gemini-2.5-flash"),
-                ("pro", ProviderType.GOOGLE, "gemini-3-pro-preview"),  # "pro" now resolves to gemini-3-pro-preview
-                ("mini", ProviderType.OPENAI, "gpt-5-mini"),  # "mini" now resolves to gpt-5-mini
+                (
+                    "pro",
+                    ProviderType.GOOGLE,
+                    "gemini-3-pro-preview",
+                ),  # "pro" now resolves to gemini-3-pro-preview
+                (
+                    "mini",
+                    ProviderType.OPENAI,
+                    "gpt-5-mini",
+                ),  # "mini" now resolves to gpt-5-mini
                 ("o3mini", ProviderType.OPENAI, "o3-mini"),
-                ("grok", ProviderType.XAI, "grok-4"),
+                ("grok", ProviderType.XAI, "grok-4-1-fast"),
                 ("grokfast", ProviderType.XAI, "grok-3-fast"),
             ]
 

--- a/tests/test_openrouter_provider.py
+++ b/tests/test_openrouter_provider.py
@@ -27,7 +27,10 @@ class TestOpenRouterProvider:
         assert "X-Title" in OpenRouterProvider.DEFAULT_HEADERS
 
         # Test with environment variables
-        with patch.dict(os.environ, {"OPENROUTER_REFERER": "https://myapp.com", "OPENROUTER_TITLE": "My App"}):
+        with patch.dict(
+            os.environ,
+            {"OPENROUTER_REFERER": "https://myapp.com", "OPENROUTER_TITLE": "My App"},
+        ):
             from importlib import reload
 
             import providers.openrouter
@@ -64,7 +67,10 @@ class TestOpenRouterProvider:
         assert caps.friendly_name == "OpenRouter (openai/o3)"
 
         # Test with a model not in registry - should raise error
-        with pytest.raises(ValueError, match="Unsupported model 'unknown-model' for provider openrouter"):
+        with pytest.raises(
+            ValueError,
+            match="Unsupported model 'unknown-model' for provider openrouter",
+        ):
             provider.get_capabilities("unknown-model")
 
         # Test with model that has provider prefix - should get generic capabilities
@@ -91,7 +97,7 @@ class TestOpenRouterProvider:
         assert provider._resolve_model_name("mistral") == "mistralai/mistral-large-2411"
         assert provider._resolve_model_name("grok-4") == "x-ai/grok-4"
         assert provider._resolve_model_name("grok4") == "x-ai/grok-4"
-        assert provider._resolve_model_name("grok") == "x-ai/grok-4"
+        assert provider._resolve_model_name("grok") == "x-ai/grok-4.1-fast"
         assert provider._resolve_model_name("deepseek") == "deepseek/deepseek-r1-0528"
         assert provider._resolve_model_name("r1") == "deepseek/deepseek-r1-0528"
 
@@ -137,7 +143,12 @@ class TestOpenRouterAutoMode:
         self.registry._initialized_providers.clear()
 
         self._original_env = {}
-        for key in ["OPENROUTER_API_KEY", "GEMINI_API_KEY", "OPENAI_API_KEY", "DEFAULT_MODEL"]:
+        for key in [
+            "OPENROUTER_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "DEFAULT_MODEL",
+        ]:
             self._original_env[key] = os.environ.get(key)
 
     def teardown_method(self):

--- a/tests/test_supported_models_aliases.py
+++ b/tests/test_supported_models_aliases.py
@@ -83,7 +83,7 @@ class TestSupportedModelsAliases:
             assert isinstance(config.aliases, list), f"{model_name} aliases must be a list"
 
         # Test specific aliases
-        assert "grok" in provider.MODEL_CAPABILITIES["grok-4"].aliases
+        assert "grok" in provider.MODEL_CAPABILITIES["grok-4-1-fast"].aliases
         assert "grok4" in provider.MODEL_CAPABILITIES["grok-4"].aliases
         assert "grok3" in provider.MODEL_CAPABILITIES["grok-3"].aliases
         assert "grok3fast" in provider.MODEL_CAPABILITIES["grok-3-fast"].aliases
@@ -94,7 +94,7 @@ class TestSupportedModelsAliases:
         assert "grokcodefast" in provider.MODEL_CAPABILITIES["grok-code-fast-1"].aliases
 
         # Test alias resolution
-        assert provider._resolve_model_name("grok") == "grok-4"
+        assert provider._resolve_model_name("grok") == "grok-4-1-fast"
         assert provider._resolve_model_name("grok4") == "grok-4"
         assert provider._resolve_model_name("grok3") == "grok-3"
         assert provider._resolve_model_name("grok3fast") == "grok-3-fast"
@@ -106,7 +106,7 @@ class TestSupportedModelsAliases:
         assert provider._resolve_model_name("grokcodefast") == "grok-code-fast-1"
 
         # Test case insensitive resolution
-        assert provider._resolve_model_name("Grok") == "grok-4"
+        assert provider._resolve_model_name("Grok") == "grok-4-1-fast"
         assert provider._resolve_model_name("GROKFAST") == "grok-3-fast"
         assert provider._resolve_model_name("GrokCodeFast") == "grok-code-fast-1"
 

--- a/tests/test_supported_models_aliases.py
+++ b/tests/test_supported_models_aliases.py
@@ -88,6 +88,10 @@ class TestSupportedModelsAliases:
         assert "grok3" in provider.MODEL_CAPABILITIES["grok-3"].aliases
         assert "grok3fast" in provider.MODEL_CAPABILITIES["grok-3-fast"].aliases
         assert "grokfast" in provider.MODEL_CAPABILITIES["grok-3-fast"].aliases
+        assert "grok-4-1-fast-reasoning" in provider.MODEL_CAPABILITIES["grok-4-1-fast"].aliases
+        assert "grok-4-1-fast-reasoning-latest" in provider.MODEL_CAPABILITIES["grok-4-1-fast"].aliases
+        assert "grok-code-fast" in provider.MODEL_CAPABILITIES["grok-code-fast-1"].aliases
+        assert "grokcodefast" in provider.MODEL_CAPABILITIES["grok-code-fast-1"].aliases
 
         # Test alias resolution
         assert provider._resolve_model_name("grok") == "grok-4"
@@ -95,10 +99,16 @@ class TestSupportedModelsAliases:
         assert provider._resolve_model_name("grok3") == "grok-3"
         assert provider._resolve_model_name("grok3fast") == "grok-3-fast"
         assert provider._resolve_model_name("grokfast") == "grok-3-fast"
+        assert provider._resolve_model_name("grok-4-1-fast") == "grok-4-1-fast"
+        assert provider._resolve_model_name("grok-4-1-fast-reasoning") == "grok-4-1-fast"
+        assert provider._resolve_model_name("grok-4-1-fast-non-reasoning") == "grok-4-1-fast-non-reasoning"
+        assert provider._resolve_model_name("grok-code-fast") == "grok-code-fast-1"
+        assert provider._resolve_model_name("grokcodefast") == "grok-code-fast-1"
 
         # Test case insensitive resolution
         assert provider._resolve_model_name("Grok") == "grok-4"
         assert provider._resolve_model_name("GROKFAST") == "grok-3-fast"
+        assert provider._resolve_model_name("GrokCodeFast") == "grok-code-fast-1"
 
     def test_dial_provider_aliases(self):
         """Test DIAL provider's alias structure."""
@@ -151,6 +161,11 @@ class TestSupportedModelsAliases:
         assert "grok" in xai_models
         assert "grok-3-fast" in xai_models
         assert "grokfast" in xai_models
+        assert "grok-4-1-fast" in xai_models
+        assert "grok-4-1-fast-reasoning" in xai_models
+        assert "grok-4-1-fast-non-reasoning" in xai_models
+        assert "grok-code-fast-1" in xai_models
+        assert "grok-code-fast" in xai_models
 
         # Test DIAL
         dial_provider = DIALModelProvider("test-key")

--- a/tests/test_xai_provider.py
+++ b/tests/test_xai_provider.py
@@ -291,7 +291,12 @@ class TestXAIProvider:
         # Shorthand "grokfast" should be allowed (resolves to grok-3-fast)
         assert provider.validate_model_name("grokfast") is True
 
-    @patch.dict(os.environ, {"XAI_ALLOWED_MODELS": "grok,grok-3,grok-4"})
+    @patch.dict(
+        os.environ,
+        {
+            "XAI_ALLOWED_MODELS": "grok,grok-3,grok-4-1-fast,grok-4",
+        },
+    )
     def test_both_shorthand_and_full_name_allowed(self):
         """Test that both shorthand and full name can be allowed."""
         # Clear cached restriction service

--- a/tests/test_xai_provider.py
+++ b/tests/test_xai_provider.py
@@ -53,6 +53,12 @@ class TestXAIProvider:
         assert provider.validate_model_name("grok3") is True
         assert provider.validate_model_name("grokfast") is True
         assert provider.validate_model_name("grok3fast") is True
+        assert provider.validate_model_name("grok-4-1-fast-reasoning") is True
+        assert provider.validate_model_name("grok-4-1-fast") is True
+        assert provider.validate_model_name("grok-4-1-fast-non-reasoning") is True
+        assert provider.validate_model_name("grok-code-fast-1") is True
+        assert provider.validate_model_name("grok-code-fast") is True
+        assert provider.validate_model_name("grokcodefast") is True
 
         # Test invalid model
         assert provider.validate_model_name("invalid-model") is False
@@ -69,6 +75,11 @@ class TestXAIProvider:
         assert provider._resolve_model_name("grok3") == "grok-3"
         assert provider._resolve_model_name("grokfast") == "grok-3-fast"
         assert provider._resolve_model_name("grok3fast") == "grok-3-fast"
+        assert provider._resolve_model_name("grok-4-1-fast") == "grok-4-1-fast"
+        assert provider._resolve_model_name("grok-4-1-fast-reasoning") == "grok-4-1-fast"
+        assert provider._resolve_model_name("grok-4-1-fast-non-reasoning") == "grok-4-1-fast-non-reasoning"
+        assert provider._resolve_model_name("grok-code-fast") == "grok-code-fast-1"
+        assert provider._resolve_model_name("grokcodefast") == "grok-code-fast-1"
 
         # Test full name passthrough
         assert provider._resolve_model_name("grok-4") == "grok-4"
@@ -125,6 +136,75 @@ class TestXAIProvider:
         assert capabilities.context_window == 131_072
         assert capabilities.provider == ProviderType.XAI
         assert not capabilities.supports_extended_thinking
+
+    def test_get_capabilities_grok4_1_fast_reasoning(self):
+        """Test getting model capabilities for GROK-4.1 Fast Reasoning."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-4-1-fast")
+        assert capabilities.model_name == "grok-4-1-fast"
+        assert capabilities.friendly_name == "X.AI (Grok 4.1 Fast Reasoning)"
+        assert capabilities.context_window == 2_000_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is True
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is True
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
+
+        # Test that alias also works
+        capabilities_alias = provider.get_capabilities("grok-4-1-fast-reasoning")
+        assert capabilities_alias.model_name == "grok-4-1-fast"
+        assert capabilities_alias.friendly_name == "X.AI (Grok 4.1 Fast Reasoning)"
+
+    def test_get_capabilities_grok4_1_fast_non_reasoning(self):
+        """Test getting model capabilities for GROK-4.1 Fast Non-Reasoning."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-4-1-fast-non-reasoning")
+        assert capabilities.model_name == "grok-4-1-fast-non-reasoning"
+        assert capabilities.friendly_name == "X.AI (Grok 4.1 Fast Non-Reasoning)"
+        assert capabilities.context_window == 2_000_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is False
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is False
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
+
+    def test_get_capabilities_grok_code_fast_1(self):
+        """Test getting model capabilities for GROK Code Fast 1."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-code-fast-1")
+        assert capabilities.model_name == "grok-code-fast-1"
+        assert capabilities.friendly_name == "X.AI (Grok Code Fast 1)"
+        assert capabilities.context_window == 256_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is True
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is False
+        assert capabilities.allow_code_generation is True
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
 
     def test_get_capabilities_with_shorthand(self):
         """Test getting model capabilities with shorthand."""
@@ -263,6 +343,9 @@ class TestXAIProvider:
         assert "grok-4" in provider.MODEL_CAPABILITIES
         assert "grok-3" in provider.MODEL_CAPABILITIES
         assert "grok-3-fast" in provider.MODEL_CAPABILITIES
+        assert "grok-4-1-fast" in provider.MODEL_CAPABILITIES
+        assert "grok-4-1-fast-non-reasoning" in provider.MODEL_CAPABILITIES
+        assert "grok-code-fast-1" in provider.MODEL_CAPABILITIES
 
         # Check model configs have required fields
         from providers.shared import ModelCapabilities
@@ -295,6 +378,24 @@ class TestXAIProvider:
         assert "grok3fast" in grok3fast_config.aliases
         assert "grokfast" in grok3fast_config.aliases
 
+        # Check new Grok-4.1 Fast models
+        grok4_1_fast_config = provider.MODEL_CAPABILITIES["grok-4-1-fast"]
+        assert grok4_1_fast_config.context_window == 2_000_000
+        assert grok4_1_fast_config.supports_extended_thinking is True
+        assert "grok-4-1-fast-reasoning" in grok4_1_fast_config.aliases
+        assert "grok-4-1-fast-reasoning-latest" in grok4_1_fast_config.aliases
+
+        grok4_1_fast_non_reasoning_config = provider.MODEL_CAPABILITIES["grok-4-1-fast-non-reasoning"]
+        assert grok4_1_fast_non_reasoning_config.context_window == 2_000_000
+        assert grok4_1_fast_non_reasoning_config.supports_extended_thinking is False
+
+        grok_code_fast_config = provider.MODEL_CAPABILITIES["grok-code-fast-1"]
+        assert grok_code_fast_config.context_window == 256_000
+        assert grok_code_fast_config.supports_extended_thinking is True
+        assert grok_code_fast_config.allow_code_generation is True
+        assert "grok-code-fast" in grok_code_fast_config.aliases
+        assert "grokcodefast" in grok_code_fast_config.aliases
+
     @patch("providers.openai_compatible.OpenAI")
     def test_generate_content_resolves_alias_before_api_call(self, mock_openai_class):
         """Test that generate_content resolves aliases before making API calls.
@@ -325,7 +426,9 @@ class TestXAIProvider:
 
         # Call generate_content with alias 'grok'
         result = provider.generate_content(
-            prompt="Test prompt", model_name="grok", temperature=0.7  # This should be resolved to "grok-4"
+            prompt="Test prompt",
+            model_name="grok",
+            temperature=0.7,  # This should be resolved to "grok-4"
         )
 
         # Verify the API was called with the RESOLVED model name

--- a/tests/test_xai_provider.py
+++ b/tests/test_xai_provider.py
@@ -377,7 +377,7 @@ class TestXAIProvider:
         assert "grok3fast" in grok3fast_config.aliases
         assert "grokfast" in grok3fast_config.aliases
 
-        # Check new Grok-4.1 Fast models
+        # Check new Grok-4-1 Fast models
         grok4_1_fast_config = provider.MODEL_CAPABILITIES["grok-4-1-fast"]
         assert grok4_1_fast_config.context_window == 2_000_000
         assert grok4_1_fast_config.supports_extended_thinking is True

--- a/tests/test_xai_provider.py
+++ b/tests/test_xai_provider.py
@@ -56,6 +56,10 @@ class TestXAIProvider:
         assert provider.validate_model_name("grok-4-1-fast-reasoning") is True
         assert provider.validate_model_name("grok-4-1-fast") is True
         assert provider.validate_model_name("grok-4-1-fast-non-reasoning") is True
+        assert provider.validate_model_name("grok-4-fast") is True
+        assert provider.validate_model_name("grok-4-fast-reasoning") is True
+        assert provider.validate_model_name("grok-4-fast-non-reasoning") is True
+        assert provider.validate_model_name("grok4fast") is True
         assert provider.validate_model_name("grok-code-fast-1") is True
         assert provider.validate_model_name("grok-code-fast") is True
         assert provider.validate_model_name("grokcodefast") is True
@@ -78,6 +82,10 @@ class TestXAIProvider:
         assert provider._resolve_model_name("grok-4-1-fast") == "grok-4-1-fast"
         assert provider._resolve_model_name("grok-4-1-fast-reasoning") == "grok-4-1-fast"
         assert provider._resolve_model_name("grok-4-1-fast-non-reasoning") == "grok-4-1-fast-non-reasoning"
+        assert provider._resolve_model_name("grok-4-fast") == "grok-4-fast"
+        assert provider._resolve_model_name("grok-4-fast-reasoning") == "grok-4-fast"
+        assert provider._resolve_model_name("grok-4-fast-non-reasoning") == "grok-4-fast-non-reasoning"
+        assert provider._resolve_model_name("grok4fast") == "grok-4-fast"
         assert provider._resolve_model_name("grok-code-fast") == "grok-code-fast-1"
         assert provider._resolve_model_name("grokcodefast") == "grok-code-fast-1"
 
@@ -184,6 +192,57 @@ class TestXAIProvider:
         assert capabilities.temperature_constraint.max_temp == 2.0
         assert capabilities.temperature_constraint.default_temp == 0.3
 
+    def test_get_capabilities_grok4_fast_reasoning(self):
+        """Test getting model capabilities for GROK-4 Fast Reasoning."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-4-fast")
+        assert capabilities.model_name == "grok-4-fast"
+        assert capabilities.friendly_name == "X.AI (Grok 4 Fast Reasoning)"
+        assert capabilities.context_window == 2_000_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is True
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is True
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
+
+        # Test that alias also works
+        capabilities_alias = provider.get_capabilities("grok-4-fast-reasoning")
+        assert capabilities_alias.model_name == "grok-4-fast"
+        assert capabilities_alias.friendly_name == "X.AI (Grok 4 Fast Reasoning)"
+
+        # Test grok4fast alias
+        capabilities_alias2 = provider.get_capabilities("grok4fast")
+        assert capabilities_alias2.model_name == "grok-4-fast"
+
+    def test_get_capabilities_grok4_fast_non_reasoning(self):
+        """Test getting model capabilities for GROK-4 Fast Non-Reasoning."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-4-fast-non-reasoning")
+        assert capabilities.model_name == "grok-4-fast-non-reasoning"
+        assert capabilities.friendly_name == "X.AI (Grok 4 Fast Non-Reasoning)"
+        assert capabilities.context_window == 2_000_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is False
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is False
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
+
     def test_get_capabilities_grok_code_fast_1(self):
         """Test getting model capabilities for GROK Code Fast 1."""
         provider = XAIModelProvider("test-key")
@@ -228,11 +287,17 @@ class TestXAIProvider:
         """X.AI capabilities should expose extended thinking support correctly."""
         provider = XAIModelProvider("test-key")
 
-        thinking_aliases = ["grok-4", "grok", "grok4"]
+        thinking_aliases = ["grok-4", "grok", "grok4", "grok-4-fast", "grok-4-1-fast"]
         for alias in thinking_aliases:
             assert provider.get_capabilities(alias).supports_extended_thinking is True
 
-        non_thinking_aliases = ["grok-3", "grok-3-fast", "grokfast"]
+        non_thinking_aliases = [
+            "grok-3",
+            "grok-3-fast",
+            "grokfast",
+            "grok-4-fast-non-reasoning",
+            "grok-4-1-fast-non-reasoning",
+        ]
         for alias in non_thinking_aliases:
             assert provider.get_capabilities(alias).supports_extended_thinking is False
 
@@ -351,6 +416,8 @@ class TestXAIProvider:
         assert "grok-3-fast" in provider.MODEL_CAPABILITIES
         assert "grok-4-1-fast" in provider.MODEL_CAPABILITIES
         assert "grok-4-1-fast-non-reasoning" in provider.MODEL_CAPABILITIES
+        assert "grok-4-fast" in provider.MODEL_CAPABILITIES
+        assert "grok-4-fast-non-reasoning" in provider.MODEL_CAPABILITIES
         assert "grok-code-fast-1" in provider.MODEL_CAPABILITIES
 
         # Check model configs have required fields
@@ -393,6 +460,18 @@ class TestXAIProvider:
         grok4_1_fast_non_reasoning_config = provider.MODEL_CAPABILITIES["grok-4-1-fast-non-reasoning"]
         assert grok4_1_fast_non_reasoning_config.context_window == 2_000_000
         assert grok4_1_fast_non_reasoning_config.supports_extended_thinking is False
+
+        # Check new Grok-4 Fast models
+        grok4_fast_config = provider.MODEL_CAPABILITIES["grok-4-fast"]
+        assert grok4_fast_config.context_window == 2_000_000
+        assert grok4_fast_config.supports_extended_thinking is True
+        assert "grok-4-fast-reasoning" in grok4_fast_config.aliases
+        assert "grok-4-fast-reasoning-latest" in grok4_fast_config.aliases
+        assert "grok4fast" in grok4_fast_config.aliases
+
+        grok4_fast_non_reasoning_config = provider.MODEL_CAPABILITIES["grok-4-fast-non-reasoning"]
+        assert grok4_fast_non_reasoning_config.context_window == 2_000_000
+        assert grok4_fast_non_reasoning_config.supports_extended_thinking is False
 
         grok_code_fast_config = provider.MODEL_CAPABILITIES["grok-code-fast-1"]
         assert grok_code_fast_config.context_window == 256_000


### PR DESCRIPTION
## Description

This PR adds support for xAI's newly released Grok 4.1 Fast models (reasoning and non-reasoning variants) released on November 19, 2025. The models feature a 2M context window and are optimized for high-performance agentic tool calling. This replaces the previous `grok-4-fast` models with the updated `grok-4-1-fast` naming convention.

## Changes Made

- [x] **Registry updates** (`conf/xai_models.json`):
  - Replaced `grok-4-fast` with `grok-4-1-fast` (primary model name)
  - Added `grok-4-1-fast-non-reasoning` entry
  - Updated aliases: `grok-4-1-fast-reasoning` → alias, `grok-4-1-fast` → primary
  - Set intelligence scores: 15 for reasoning variant, 13 for non-reasoning
  - Configured capability flags (reasoning, function calling, JSON mode, images)

- [x] **OpenRouter updates** (`conf/openrouter_models.json`):
  - Updated model name to `x-ai/grok-4.1-fast` (matching OpenRouter API identifier)
  - Updated aliases and description per OpenRouter model card

- [x] **Provider logic** (`providers/xai.py`):
  - Updated model preference lists for EXTENDED_REASONING, FAST_RESPONSE, and BALANCED categories
  - Changed references from `grok-4-fast` to `grok-4-1-fast`

- [x] **Test updates**:
  - Updated `tests/test_xai_provider.py` - Model validation, resolution, and capability tests
  - Updated `tests/test_supported_models_aliases.py` - Alias resolution and case-insensitive tests
  - Updated `tests/test_auto_mode_comprehensive.py` - Auto-mode model assignments

- [x] **Documentation updates**:
  - `docs/custom_models.md` - Added Grok 4.1 Fast to latest xAI releases section
  - `docs/configuration.md` - Updated provider table and XAI_ALLOWED_MODELS examples
  - `docs/advanced-usage.md` - Updated model table and all tool parameter lists
  - `docs/model_ranking.md` - Added Grok 4.1 Fast models to intelligence score guidance
  - All tool docs (`docs/tools/*.md`) - Updated model parameter lists (9 files)

- [ ] No breaking changes (aliases maintain backward compatibility)
- [ ] No dependencies added/removed

## Testing

**Please review our [Testing Guide](../docs/testing.md) before submitting.**

### Run all linting and tests (required):
```bash
# Activate virtual environment first
source .zen_venv/bin/activate

# Run comprehensive code quality checks (recommended)
./code_quality_checks.sh

# Run specific test suites
pytest tests/test_xai_provider.py -v
pytest tests/test_supported_models_aliases.py -v
pytest tests/test_auto_mode_comprehensive.py -v
```

- [x] All linting passes (ruff, black, isort)
- [x] All unit tests pass
- [x] **For new features**: Unit tests updated in `tests/`
- [ ] **For tool changes**: Simulator tests added in `simulator_tests/` (N/A - no tool changes)
- [x] **For bug fixes**: Tests updated to prevent regression
- [x] Manual testing completed with realistic scenarios

## Related Issues

Fixes #339 

## Checklist

- [x] PR title follows the format guidelines above
- [x] **Activated venv and ran code quality checks: `source .zen_venv/bin/activate && ./code_quality_checks.sh`**
- [x] Self-review completed
- [x] **Tests added for ALL changes** (see Testing section above)
- [x] Documentation updated as needed
- [x] All unit tests passing
- [x] Relevant simulator tests passing (if tool changes) - N/A
- [x] Ready for review

## Additional Notes

### Model Naming Convention

The primary model name is `grok-4-1-fast` (following xAI's official naming), with `grok-4-1-fast-reasoning` as an alias. This aligns with the pattern where shorter names are preferred as primary identifiers.

### OpenRouter Model Identifier

OpenRouter uses `x-ai/grok-4.1-fast` (with a dot) as the API identifier, which differs from the native xAI naming. The configuration correctly maps to this identifier.

### Backward Compatibility

All previous references to `grok-4-fast` have been updated. The alias system ensures that if any external code references the old names, they will resolve correctly through the alias mechanism.

### Intelligence Scores

- `grok-4-1-fast`: 15 (Strong general models with large context)
- `grok-4-1-fast-non-reasoning`: 13 (Balanced assistants)

These scores align with the model ranking guidance in `docs/model_ranking.md`.