### PR TITLE
feat(gemini): Update Gemini 3.0 Pro to intelligence score 20

### DIFF
--- a/conf/gemini_models.json
+++ b/conf/gemini_models.json
@@ -33,8 +33,8 @@
         "gemini3",
         "gemini-pro"
       ],
-      "intelligence_score": 18,
-      "description": "Deep reasoning + thinking mode (1M context) - Complex problems, architecture, deep analysis",
+      "intelligence_score": 20,
+      "description": "Flagship model with deep reasoning + thinking mode (1M context) - Complex problems, architecture, deep analysis",
       "context_window": 1048576,
       "max_output_tokens": 65536,
       "max_thinking_tokens": 32768,


### PR DESCRIPTION
## Summary
Updates Gemini 3.0 Pro to intelligence score 20 (highest tier) for proper auto-selection prioritization.

## Changes
- `intelligence_score`: 18 → 20
- Description updated to "flagship model"
- Ensures top prioritization in auto mode

## Rationale
Gemini 3.0 Pro is the flagship model with superior reasoning capabilities and should be ranked at the highest tier for auto-selection. This ensures it's properly prioritized when users rely on auto mode to select the best model for complex tasks.

## Impact
- Better model selection in auto mode
- Aligns with model's actual capabilities
- No breaking changes

## Files Changed
- 1 file changed: `conf/gemini_models.json`
- 2 insertions, 2 deletions