### PR TITLE
feat: Add Claude Code Agent Skills support (standalone mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 ### Your CLI + Multiple Models = Your AI Dev Team
 
-**Use the 🤖 CLI you love:**  
+**Use the 🤖 CLI you love:**
 [Claude Code](https://www.anthropic.com/claude-code) · [Gemini CLI](https://github.com/google-gemini/gemini-cli) · [Codex CLI](https://github.com/openai/codex) · [Qwen Code CLI](https://qwenlm.github.io/qwen-code-docs/) · [Cursor](https://cursor.com) · _and more_
 
-**With multiple models within a single prompt:**  
-Gemini · OpenAI · Anthropic · Grok · Azure · Ollama · OpenRouter · DIAL · On-Device Model
+**With multiple models within a single prompt:**
+Gemini · OpenAI · DeepSeek · Anthropic · Grok · Azure · Ollama · OpenRouter · DIAL · On-Device Model
 
 </div>
 
@@ -128,7 +128,7 @@ and review into consideration to aid with its final pre-commit review.
 For best results when using [Claude Code](https://claude.ai/code):  
 
 - **Sonnet 4.5** - All agentic work and orchestration
-- **Gemini 3.0 Pro** OR **GPT-5.2 / Pro** - Deep thinking, additional code reviews, debugging and validations, pre-commit analysis
+- **Gemini 3.0 Pro** OR **GPT-5-Pro** - Deep thinking, additional code reviews, debugging and validations, pre-commit analysis
 </details>
 
 <details>
@@ -136,8 +136,8 @@ For best results when using [Claude Code](https://claude.ai/code):
 
 For best results when using [Codex CLI](https://developers.openai.com/codex/cli):  
 
-- **GPT-5.2 Codex Medium** - All agentic work and orchestration
-- **Gemini 3.0 Pro** OR **GPT-5.2-Pro** - Deep thinking, additional code reviews, debugging and validations, pre-commit analysis
+- **GPT-5 Codex Medium** - All agentic work and orchestration
+- **Gemini 3.0 Pro** OR **GPT-5-Pro** - Deep thinking, additional code reviews, debugging and validations, pre-commit analysis
 </details>
 
 ## Quick Start (5 minutes)
@@ -148,6 +148,7 @@ For best results when using [Codex CLI](https://developers.openai.com/codex/cli)
 - **[OpenRouter](https://openrouter.ai/)** - Access multiple models with one API
 - **[Gemini](https://makersuite.google.com/app/apikey)** - Google's latest models
 - **[OpenAI](https://platform.openai.com/api-keys)** - O3, GPT-5 series
+- **[DeepSeek](https://platform.deepseek.com/)** - DeepSeek V3.1 models
 - **[Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/)** - Enterprise deployments of GPT-4o, GPT-4.1, GPT-5 family
 - **[X.AI](https://console.x.ai/)** - Grok models
 - **[DIAL](https://dialx.ai/)** - Vendor-agnostic model access
@@ -178,6 +179,7 @@ cd pal-mcp-server
       "env": {
         "PATH": "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin:~/.local/bin",
         "GEMINI_API_KEY": "your-key-here",
+        "DEEPSEEK_API_KEY": "your-deepseek-key-here",
         "DISABLED_TOOLS": "analyze,refactor,testgen,secaudit,docgen,tracer",
         "DEFAULT_MODEL": "auto"
       }
@@ -185,6 +187,10 @@ cd pal-mcp-server
   }
 }
 ```
+
+**Option C: Claude Code Agent Skills** (standalone mode)
+
+Skills are standalone executables that run without MCP server - see [Skills Mode](#-claude-code-agent-skills) section below.
 
 **3. Start Using!**
 ```
@@ -208,7 +214,7 @@ PAL activates any provider that has credentials in your `.env`. See `.env.exampl
 
 **Collaboration & Planning** *(Enabled by default)*
 - **[`clink`](docs/tools/clink.md)** - Bridge requests to external AI CLIs (Gemini planner, codereviewer, etc.)
-- **[`chat`](docs/tools/chat.md)** - Brainstorm ideas, get second opinions, validate approaches. With capable models (GPT-5.2 Pro, Gemini 3.0 Pro), generates complete code / implementation
+- **[`chat`](docs/tools/chat.md)** - Brainstorm ideas, get second opinions, validate approaches. With capable models (GPT-5 Pro, Gemini 3.0 Pro), generates complete code / implementation
 - **[`thinkdeep`](docs/tools/thinkdeep.md)** - Extended reasoning, edge case analysis, alternative perspectives
 - **[`planner`](docs/tools/planner.md)** - Break down complex projects into structured, actionable plans
 - **[`consensus`](docs/tools/consensus.md)** - Get expert opinions from multiple AI models with stance steering
@@ -278,6 +284,8 @@ DISABLED_TOOLS=
         // API configuration
         "GEMINI_API_KEY": "your-gemini-key",
         "OPENAI_API_KEY": "your-openai-key",
+        "DEEPSEEK_API_KEY": "your-deepseek-key",
+        "DEEPSEEK_BASE_URL": "https://api.deepseek.com",  // Optional custom endpoint
         "OPENROUTER_API_KEY": "your-openrouter-key",
         
         // Logging and performance
@@ -381,8 +389,8 @@ DISABLED_TOOLS=
 - **[Context revival](docs/context-revival.md)** - Continue conversations even after context resets
 
 **Model Support**
-- **Multiple providers** - Gemini, OpenAI, Azure, X.AI, OpenRouter, DIAL, Ollama
-- **Latest models** - GPT-5, Gemini 3.0 Pro, O3, Grok-4, local Llama
+- **Multiple providers** - Gemini, OpenAI, DeepSeek, Azure, X.AI, OpenRouter, DIAL, Ollama
+- **Latest models** - GPT-5, Gemini 3.0 Pro, O3, DeepSeek V3.1, Grok-4, local Llama
 - **[Thinking modes](docs/advanced-usage.md#thinking-modes)** - Control reasoning depth vs cost
 - **Vision support** - Analyze images, diagrams, screenshots
 
@@ -414,6 +422,42 @@ DISABLED_TOOLS=
 
 👉 **[Advanced Usage Guide](docs/advanced-usage.md)** for complex workflows, model configuration, and power-user features
 
+## 🎯 Claude Code Agent Skills
+
+PAL also supports **Claude Code Agent Skills** - standalone executables that can be invoked directly by Claude Code without running the MCP server.
+
+**Why Skills?** Reduces token overhead - tool descriptions are only loaded when invoked, not always present in your context window.
+
+**Shared Conversation Memory:** Skills use SQLite (`~/.pal_mcp/sessions.db`) to persist conversations across invocations, enabling multi-turn workflows just like MCP mode.
+
+### Installation
+
+**Requirements:** Python 3.10+, macOS/Linux, [Claude Code](https://www.anthropic.com/claude-code) installed
+
+```bash
+git clone https://github.com/BeehiveInnovations/pal-mcp-server.git
+cd pal-mcp-server
+
+# Install all 17 skills to ~/.claude/skills/
+./install-skills.sh
+
+# Or install specific skills
+./install-skills.sh pal-chat pal-thinkdeep pal-codereview
+
+# Update: re-run to overwrite existing skills
+./install-skills.sh
+```
+
+Skills use the same environment variables as MCP mode (`GEMINI_API_KEY`, `OPENAI_API_KEY`, etc.).
+
+**Verify installation:**
+```
+# In Claude Code, try:
+"Use pal-chat to say hello with gemini flash"
+```
+
+> **Note:** This is an **experimental implementation** - interfaces may change. Feedback welcome on [#346](https://github.com/BeehiveInnovations/pal-mcp-server/issues/346).
+
 ## Quick Links
 
 **📖 Documentation**
@@ -443,6 +487,7 @@ Built with the power of **Multi-Model AI** collaboration 🤝
 - [Claude Code](https://claude.ai/code)
 - [Gemini](https://ai.google.dev/)
 - [OpenAI](https://openai.com/)
+- [DeepSeek](https://platform.deepseek.com/)
 - [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/)
 
 ### Star History

--- a/install-skills.sh
+++ b/install-skills.sh
@@ -1,0 +1,454 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Zen Skills Installation Script
+#
+# Install Zen Skills to ~/.claude/skills/ for Claude Code integration.
+# This script is independent of the MCP server setup.
+#
+# Usage:
+#   ./install-skills.sh              Install core skills only
+#   ./install-skills.sh --all        Install core + optional skills
+#   ./install-skills.sh --force      Force overwrite without prompting
+#   ./install-skills.sh --help       Show help
+#
+# Environment variables:
+#   FORCE=1                 Skip overwrite confirmation
+#   CLAUDE_SKILLS_HOME      Custom skills installation directory
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# Colors and Output Functions
+# ----------------------------------------------------------------------------
+
+readonly GREEN='\033[0;32m'
+readonly YELLOW='\033[1;33m'
+readonly RED='\033[0;31m'
+readonly NC='\033[0m'
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1" >&2
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1" >&2
+}
+
+print_warning() {
+    echo -e "${YELLOW}!${NC} $1"
+}
+
+print_info() {
+    echo -e "${YELLOW}$1${NC}"
+}
+
+# ----------------------------------------------------------------------------
+# Helper Functions
+# ----------------------------------------------------------------------------
+
+get_script_dir() {
+    cd "$(dirname "$0")" && pwd
+}
+
+# Safe removal function with path validation
+# Ensures we only delete directories under ~/.claude/skills/
+safe_rm() {
+    local target="$1"
+
+    # Reject empty or unset paths
+    if [[ -z "$target" ]]; then
+        print_error "safe_rm: target path is empty"
+        return 1
+    fi
+
+    # Get absolute canonical path
+    local real_target
+    if [[ -e "$target" ]]; then
+        real_target=$(realpath "$target")
+    else
+        # If target doesn't exist, get realpath of parent and append basename
+        local parent=$(dirname "$target")
+        local basename=$(basename "$target")
+        if [[ -e "$parent" ]]; then
+            real_target=$(realpath "$parent")/"$basename"
+        else
+            # Parent doesn't exist either, skip (nothing to delete)
+            return 0
+        fi
+    fi
+
+    # Define safe base directory (where skills should be installed)
+    local skills_base=$(realpath "${CLAUDE_SKILLS_HOME:-$HOME/.claude/skills}")
+
+    # Dangerous paths that should never be deleted
+    local dangerous_paths=(
+        "/"
+        "/home"
+        "/root"
+        "/usr"
+        "/bin"
+        "/sbin"
+        "/etc"
+        "/var"
+        "/opt"
+        "$HOME"
+        "$(realpath ~)"
+    )
+
+    # Check if target is a dangerous path
+    for dangerous in "${dangerous_paths[@]}"; do
+        if [[ "$real_target" == "$dangerous" ]]; then
+            print_error "safe_rm: refusing to delete dangerous path: $real_target"
+            return 1
+        fi
+    done
+
+    # Ensure target is under the skills base directory
+    if [[ "$real_target" != "$skills_base"/* ]]; then
+        print_error "safe_rm: target must be under $skills_base, got: $real_target"
+        return 1
+    fi
+
+    # All safety checks passed, perform deletion
+    if [[ -e "$target" ]]; then
+        rm -rf "$target"
+    fi
+
+    return 0
+}
+
+# Get available CLI clients from conf/cli_clients/*.json
+get_available_cli_clients() {
+    local script_dir="$1"
+    local cli_dir="$script_dir/conf/cli_clients"
+    local clients=""
+
+    if [[ -d "$cli_dir" ]]; then
+        for json_file in "$cli_dir"/*.json; do
+            if [[ -f "$json_file" ]]; then
+                # Extract name field from JSON (simple grep-based extraction)
+                local name=$(grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' "$json_file" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+                if [[ -n "$name" ]]; then
+                    if [[ -n "$clients" ]]; then
+                        clients="$clients, $name"
+                    else
+                        clients="$name"
+                    fi
+                fi
+            fi
+        done
+    fi
+
+    echo "$clients"
+}
+
+# Update pal-clink SKILL.md with dynamic description of available CLI clients
+update_clink_description() {
+    local target_dir="$1"
+    local script_dir="$2"
+    local skill_md="$target_dir/SKILL.md"
+
+    if [[ ! -f "$skill_md" ]]; then
+        return 0
+    fi
+
+    # Get available CLI clients
+    local clients=$(get_available_cli_clients "$script_dir")
+
+    if [[ -z "$clients" ]]; then
+        return 0
+    fi
+
+    # Create new description with available clients
+    local new_desc="description: Bridges to external AI CLIs ($clients) for cross-model collaboration and specialized capabilities."
+
+    # Replace the description line in SKILL.md
+    if [[ "$(uname)" == "Darwin" ]]; then
+        # macOS sed requires different syntax
+        sed -i '' "s/^description:.*/$new_desc/" "$skill_md"
+    else
+        sed -i "s/^description:.*/$new_desc/" "$skill_md"
+    fi
+}
+
+show_help() {
+    echo "Zen Skills Installation Script"
+    echo ""
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --all       Install all skills (core + optional)"
+    echo "  --force     Force overwrite existing skills without prompting"
+    echo "  --help      Show this help message"
+    echo ""
+    echo "Environment variables:"
+    echo "  FORCE=1              Same as --force"
+    echo "  CLAUDE_SKILLS_HOME   Custom installation directory (default: ~/.claude/skills)"
+    echo ""
+    echo "Examples:"
+    echo "  $0                   Install core skills only"
+    echo "  $0 --all             Install all skills"
+    echo "  $0 --all --force     Install all skills, overwrite existing"
+    echo "  FORCE=1 $0 --all     Same as above"
+}
+
+# ----------------------------------------------------------------------------
+# Skills Installation Functions
+# ----------------------------------------------------------------------------
+
+create_skill_symlinks() {
+    local skills_target="$1"
+    local bin_dir="${HOME}/.local/bin"
+
+    # Create bin directory if it doesn't exist
+    mkdir -p "$bin_dir"
+
+    # Create symlinks for each skill
+    local symlinks_created=0
+    for skill_dir in "$skills_target"/pal-*/; do
+        if [[ -d "$skill_dir" ]] && [[ -f "$skill_dir/run.sh" ]]; then
+            local skill_name=$(basename "$skill_dir")
+            local symlink_path="$bin_dir/$skill_name"
+
+            # Remove existing symlink if present
+            if [[ -L "$symlink_path" ]]; then
+                rm "$symlink_path"
+            fi
+
+            # Create symlink
+            ln -s "$skill_dir/run.sh" "$symlink_path"
+            symlinks_created=$((symlinks_created + 1))
+        fi
+    done
+
+    if [[ $symlinks_created -gt 0 ]]; then
+        echo ""
+        print_success "Created $symlinks_created command symlinks in $bin_dir"
+
+        # Check if ~/.local/bin is in PATH
+        if [[ ":$PATH:" != *":$bin_dir:"* ]]; then
+            print_warning "$bin_dir is not in your PATH"
+            echo "Add this to your ~/.bashrc or ~/.zshrc:"
+            echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+        fi
+    fi
+}
+
+install_skills_from_dir() {
+    local skills_source="$1"
+    local skills_target="$2"
+    local runner_source="$3"
+    local script_dir="$4"
+    local skill_type="$5"  # "core" or "optional"
+    local installed=0
+    local skill_names=""
+
+    for skill_dir in "$skills_source"/pal-*/; do
+        if [[ -d "$skill_dir" ]] && [[ -f "$skill_dir/SKILL.md" ]]; then
+            local skill_name=$(basename "$skill_dir")
+            local target_dir="$skills_target/$skill_name"
+
+            # Remove existing skill directory with safety checks
+            if [[ -d "$target_dir" ]]; then
+                safe_rm "$target_dir" || {
+                    print_error "Failed to safely remove existing skill: $target_dir"
+                    return 1
+                }
+            fi
+
+            # Copy skill directory
+            cp -r "$skill_dir" "$target_dir"
+
+            # Create scripts directory and copy runner
+            mkdir -p "$target_dir/scripts"
+            cp "$runner_source" "$target_dir/scripts/"
+
+            # Set PAL_MCP_ROOT in a config file for the skill
+            echo "PAL_MCP_ROOT=\"$script_dir\"" > "$target_dir/scripts/.pal_config"
+
+            # Make run.sh executable
+            if [[ -f "$target_dir/run.sh" ]]; then
+                chmod +x "$target_dir/run.sh"
+            fi
+
+            # Update pal-clink description with available CLI clients
+            if [[ "$skill_name" == "pal-clink" ]]; then
+                update_clink_description "$target_dir" "$script_dir"
+            fi
+
+            if [[ "$skill_type" == "optional" ]]; then
+                print_success "Installed (optional): $skill_name"
+            else
+                print_success "Installed: $skill_name"
+            fi
+            skill_names="$skill_names  - $skill_name\n"
+            installed=$((installed + 1))
+        fi
+    done
+
+    echo "$installed|$skill_names"
+}
+
+install_skills() {
+    local script_dir=$(get_script_dir)
+    local skills_source="$script_dir/skills"
+    local skills_optional="$script_dir/skills-optional"
+    local skills_target="${CLAUDE_SKILLS_HOME:-$HOME/.claude/skills}"
+    local runner_source="$script_dir/scripts/pal_skill_runner.py"
+    local force_overwrite="${FORCE:-0}"
+    local install_all="${INSTALL_ALL:-0}"
+
+    echo ""
+    if [[ "$install_all" == "1" ]]; then
+        print_info "Installing Zen Skills (core + optional)..."
+    else
+        print_info "Installing Zen Skills (core only)..."
+        echo "Tip: Use --all to also install optional skills (analyze, refactor, testgen, etc.)"
+    fi
+    echo ""
+
+    # Check source directory
+    if [[ ! -d "$skills_source" ]]; then
+        print_error "Skills source directory not found: $skills_source"
+        return 1
+    fi
+
+    # Check runner script
+    if [[ ! -f "$runner_source" ]]; then
+        print_error "Skill runner not found: $runner_source"
+        return 1
+    fi
+
+    # Check if any skills already exist
+    local existing_skills=""
+    for skill_dir in "$skills_source"/pal-*/; do
+        if [[ -d "$skill_dir" ]] && [[ -f "$skill_dir/SKILL.md" ]]; then
+            local skill_name=$(basename "$skill_dir")
+            local target_dir="$skills_target/$skill_name"
+            if [[ -d "$target_dir" ]]; then
+                existing_skills="$existing_skills $skill_name"
+            fi
+        fi
+    done
+    if [[ "$install_all" == "1" ]] && [[ -d "$skills_optional" ]]; then
+        for skill_dir in "$skills_optional"/pal-*/; do
+            if [[ -d "$skill_dir" ]] && [[ -f "$skill_dir/SKILL.md" ]]; then
+                local skill_name=$(basename "$skill_dir")
+                local target_dir="$skills_target/$skill_name"
+                if [[ -d "$target_dir" ]]; then
+                    existing_skills="$existing_skills $skill_name"
+                fi
+            fi
+        done
+    fi
+
+    # Prompt user if skills already exist
+    if [[ -n "$existing_skills" ]] && [[ "$force_overwrite" != "1" ]]; then
+        echo ""
+        print_warning "The following skills already exist:"
+        for skill in $existing_skills; do
+            echo "  - $skill"
+        done
+        echo ""
+        read -p "Overwrite existing skills? [y/N] " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_info "Installation cancelled."
+            echo "Tip: Use --force or FORCE=1 to skip this prompt."
+            return 0
+        fi
+    fi
+
+    # Clean up old unified "zen" skill if exists (migration from old structure)
+    if [[ -d "$skills_target/zen" ]] && [[ ! -d "$skills_target/pal-chat" ]]; then
+        print_info "Removing old unified skill structure..."
+        safe_rm "$skills_target/zen" || {
+            print_error "Failed to safely remove old skill structure: $skills_target/zen"
+            return 1
+        }
+    fi
+
+    # Create target directory
+    mkdir -p "$skills_target"
+
+    # Install core skills
+    local result=$(install_skills_from_dir "$skills_source" "$skills_target" "$runner_source" "$script_dir" "core")
+    local core_installed=$(echo "$result" | cut -d'|' -f1)
+    local core_names=$(echo "$result" | cut -d'|' -f2-)
+
+    # Install optional skills if requested
+    local optional_installed=0
+    local optional_names=""
+    if [[ "$install_all" == "1" ]] && [[ -d "$skills_optional" ]]; then
+        result=$(install_skills_from_dir "$skills_optional" "$skills_target" "$runner_source" "$script_dir" "optional")
+        optional_installed=$(echo "$result" | cut -d'|' -f1)
+        optional_names=$(echo "$result" | cut -d'|' -f2-)
+    fi
+
+    local total_installed=$((core_installed + optional_installed))
+
+    if [[ $total_installed -gt 0 ]]; then
+        echo ""
+        print_success "Installed $total_installed skills to $skills_target"
+        echo ""
+        if [[ $core_installed -gt 0 ]]; then
+            echo "Core skills ($core_installed):"
+            echo -e "$core_names"
+        fi
+        if [[ $optional_installed -gt 0 ]]; then
+            echo "Optional skills ($optional_installed):"
+            echo -e "$optional_names"
+        fi
+
+        # Create symlinks in ~/.local/bin for direct command access
+        create_skill_symlinks "$skills_target"
+
+        echo ""
+        echo "Skills are now available in Claude Code."
+        echo "You can call skills directly: pal-chat --prompt \"...\""
+        echo "Or via full path: ~/.claude/skills/pal-chat/run.sh --prompt \"...\""
+        echo ""
+        echo "Claude will automatically discover and use them based on context."
+    else
+        print_warning "No skills found to install in $skills_source"
+        echo "Expected structure: skills/pal-*/SKILL.md"
+    fi
+
+    return 0
+}
+
+# ----------------------------------------------------------------------------
+# Main Entry Point
+# ----------------------------------------------------------------------------
+
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --all)
+                INSTALL_ALL=1
+                shift
+                ;;
+            --force)
+                FORCE=1
+                shift
+                ;;
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                echo ""
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+
+    # Run installation
+    install_skills
+}
+
+main "$@"

--- a/scripts/pal_skill_runner.py
+++ b/scripts/pal_skill_runner.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""
+PAL Skill Runner - Lightweight CLI entry point for calling PAL tools directly.
+
+This runner executes tools without starting the MCP server, making it suitable
+for Skills mode where tools are called directly from the command line.
+
+Usage:
+    python pal_skill_runner.py --skill pal-chat --input '{"prompt": "...", ...}'
+    echo '{"prompt": "..."}' | python pal_skill_runner.py --skill pal-chat
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+# =============================================================================
+# Skill Registry - Maps skill names to tool module paths
+# =============================================================================
+
+SKILL_REGISTRY = {
+    # Core skills
+    "pal-chat": "tools.chat:ChatTool",
+    "pal-thinkdeep": "tools.thinkdeep:ThinkDeepTool",
+    "pal-codereview": "tools.codereview:CodeReviewTool",
+    "pal-planner": "tools.planner:PlannerTool",
+    "pal-consensus": "tools.consensus:ConsensusTool",
+    "pal-debug": "tools.debug:DebugIssueTool",
+    "pal-precommit": "tools.precommit:PrecommitTool",
+    "pal-challenge": "tools.challenge:ChallengeTool",
+    "pal-apilookup": "tools.apilookup:LookupTool",
+    "pal-clink": "tools.clink:CLinkTool",
+    "pal-listmodels": "tools.listmodels:ListModelsTool",
+    # Optional skills
+    "pal-analyze": "tools.analyze:AnalyzeTool",
+    "pal-refactor": "tools.refactor:RefactorTool",
+    "pal-testgen": "tools.testgen:TestGenTool",
+    "pal-secaudit": "tools.secaudit:SecauditTool",
+    "pal-docgen": "tools.docgen:DocgenTool",
+    "pal-tracer": "tools.tracer:TracerTool",
+}
+
+# =============================================================================
+# Path Resolution
+# =============================================================================
+
+
+def resolve_pal_root() -> Path:
+    """
+    Resolve the PAL MCP Server root directory.
+
+    Priority:
+    1. PAL_MCP_SERVER_ROOT environment variable
+    2. .pal_config file in scripts directory (written during installation)
+    3. Parent of this script's directory (development mode)
+    """
+    # 1. Environment variable
+    env_root = os.getenv("PAL_MCP_SERVER_ROOT")
+    if env_root:
+        root = Path(env_root).expanduser().resolve()
+        if root.exists():
+            return root
+
+    # 2. Config file (written during installation)
+    script_dir = Path(__file__).resolve().parent
+    config_file = script_dir / ".pal_config"
+    if config_file.exists():
+        try:
+            content = config_file.read_text().strip()
+            # Parse PAL_MCP_ROOT="..." format
+            for line in content.split("\n"):
+                if line.startswith("PAL_MCP_ROOT="):
+                    root_path = line.split("=", 1)[1].strip().strip('"')
+                    root = Path(root_path).expanduser().resolve()
+                    if root.exists():
+                        return root
+        except Exception:
+            pass
+
+    # 3. Development mode: parent of scripts directory
+    dev_root = script_dir.parent
+    if (dev_root / "server.py").exists():
+        return dev_root
+
+    raise RuntimeError(
+        "Cannot find PAL MCP Server root. "
+        "Set PAL_MCP_SERVER_ROOT environment variable or run from project directory."
+    )
+
+
+# =============================================================================
+# Environment Setup
+# =============================================================================
+
+
+def setup_environment(root: Path) -> None:
+    """
+    Set up the Python environment for tool execution.
+
+    This includes:
+    1. Adding the project root to sys.path
+    2. Loading .env file
+    3. Configuring AI providers (without importing server.py to avoid MCP init)
+    4. Disabling verbose logging for clean output
+    """
+    # Add root to path
+    root_str = str(root)
+    if root_str not in sys.path:
+        sys.path.insert(0, root_str)
+
+    # Change to project root for relative path resolution
+    os.chdir(root)
+
+    # Force .env to override system environment variables for Skills mode
+    # This ensures Skills use the project's .env configuration, not system env
+    os.environ["PAL_MCP_FORCE_ENV_OVERRIDE"] = "true"
+
+    # Enable SQLite storage for Skills mode (cross-process session persistence)
+    # This allows continuation_id to work across separate skill invocations
+    #
+    # NOTE: Storage backend difference between modes:
+    # - MCP Server mode: Uses in-memory storage (fast, single-process)
+    # - Skills mode: Uses SQLite storage (cross-process persistence required)
+    #
+    # Sessions are isolated by default - continuation_id from one mode won't work in the other.
+    # Database location: ~/.pal_mcp/sessions.db (or set PAL_SKILL_STORAGE_PATH to override)
+    os.environ["PAL_SKILL_STORAGE"] = "sqlite"
+
+    # Configure logging level for Skills mode
+    # Use PAL_SKILL_LOG_LEVEL environment variable to control verbosity
+    # Default: WARNING (suppress INFO/DEBUG messages for clean JSON output)
+    # Options: DEBUG, INFO, WARNING, ERROR
+    import logging
+
+    log_level = os.environ.get("PAL_SKILL_LOG_LEVEL", "WARNING").upper()
+    level = getattr(logging, log_level, logging.WARNING)
+    logging.getLogger().setLevel(level)
+
+    # Also apply same level to specific noisy loggers
+    for logger_name in ["httpx", "httpcore", "openai", "utils", "tools", "providers"]:
+        logging.getLogger(logger_name).setLevel(level)
+
+    # Load environment variables from .env
+    from utils.env import get_env, reload_env
+
+    reload_env()
+
+    # Configure AI providers using shared configuration
+    # This ensures provider registration is consistent with MCP server mode
+    # NOTE: require_at_least_one=True matches MCP server behavior (server.py:544-554)
+    from providers.configuration import register_providers
+
+    # Enable verbose logging for provider restrictions when log level is DEBUG or INFO
+    verbose = level <= logging.INFO
+    logger = logging.getLogger("pal_skill_runner") if verbose else None
+
+    register_providers(get_env, verbose=verbose, logger=logger, require_at_least_one=True)
+
+
+# =============================================================================
+# Payload Handling
+# =============================================================================
+
+
+def load_payload(input_arg: str | None) -> dict:
+    """
+    Load the input payload from argument or stdin.
+
+    Args:
+        input_arg: JSON string or file path from --input argument
+
+    Returns:
+        Parsed dictionary payload
+    """
+    if input_arg:
+        input_arg = input_arg.strip()
+
+        # First, check if it looks like JSON (starts with { or [)
+        # This avoids OSError "File name too long" when passing long JSON strings
+        if input_arg.startswith("{") or input_arg.startswith("["):
+            return json.loads(input_arg)
+
+        # Check if it's a file path (only for non-JSON-looking strings)
+        try:
+            if Path(input_arg).exists():
+                return json.loads(Path(input_arg).read_text())
+        except OSError:
+            # Path too long or other OS error - not a valid file path
+            pass
+
+        # Try parsing as JSON string anyway (handles edge cases)
+        return json.loads(input_arg)
+
+    # Try reading from stdin
+    if not sys.stdin.isatty():
+        data = sys.stdin.read().strip()
+        if data:
+            return json.loads(data)
+
+    raise ValueError("No input provided. Use --input '{...}' or pipe JSON to stdin.")
+
+
+def auto_fill_common_fields(payload: dict, skill_name: str) -> dict:
+    """
+    Auto-fill common required fields that can be inferred from context.
+
+    This improves usability by automatically providing values that Claude Code
+    knows (like current working directory) but may forget to include.
+
+    Args:
+        payload: Input parameters dictionary
+        skill_name: The skill being executed
+
+    Returns:
+        Updated payload with auto-filled fields
+    """
+    original_cwd = os.environ.get("SKILL_ORIGINAL_CWD") or str(Path.home())
+
+    # Auto-fill working_directory_absolute_path for tools that need it
+    SKILLS_NEEDING_WORKING_DIR = {"pal-chat"}
+    if skill_name in SKILLS_NEEDING_WORKING_DIR:
+        if "working_directory_absolute_path" not in payload:
+            payload["working_directory_absolute_path"] = original_cwd
+
+    # Normalize file path fields - convert relative paths to absolute paths
+    # based on the original working directory (not the pal-mcp-server directory)
+    # _normalize_path handles URIs (http://, data:, etc.) and ~ expansion
+    PATH_FIELDS = [
+        "absolute_file_paths",
+        "files_checked",
+        "relevant_files",
+        "images",
+        "style_guide_examples",
+        "path",  # for precommit
+        "working_directory_absolute_path",  # also normalize if provided
+    ]
+
+    for field in PATH_FIELDS:
+        if field in payload:
+            value = payload[field]
+            if isinstance(value, list):
+                # Normalize each path in the list
+                normalized = []
+                for p in value:
+                    if isinstance(p, str) and p:
+                        normalized.append(_normalize_path(p, original_cwd))
+                    else:
+                        normalized.append(p)
+                payload[field] = normalized
+            elif isinstance(value, str) and value:
+                payload[field] = _normalize_path(value, original_cwd)
+
+    return payload
+
+
+def _normalize_path(path: str, base_dir: str) -> str:
+    """
+    Normalize a file path to absolute path.
+
+    If the path is relative, resolve it relative to base_dir.
+    If already absolute, return as-is.
+    Handles special cases: URIs, ~ expansion, etc.
+
+    Args:
+        path: File path (may be relative or absolute)
+        base_dir: Base directory for resolving relative paths
+
+    Returns:
+        Absolute path (or original if URI)
+    """
+    if not path:
+        return path
+
+    # Skip URIs (http://, https://, file://, data:, etc.)
+    import re
+
+    if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*:", path):
+        return path
+
+    # Expand ~ to user home directory
+    path_obj = Path(path).expanduser()
+
+    # Already absolute after expansion
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    # Resolve relative path against base_dir
+    return str((Path(base_dir) / path_obj).resolve())
+
+
+# =============================================================================
+# Tool Execution
+# =============================================================================
+
+
+def get_tool_instance(skill_name: str):
+    """
+    Get a tool instance by skill name.
+
+    Args:
+        skill_name: The skill name (e.g., "pal-chat")
+
+    Returns:
+        Instantiated tool object
+    """
+    if skill_name not in SKILL_REGISTRY:
+        available = ", ".join(sorted(SKILL_REGISTRY.keys()))
+        raise ValueError(f"Unknown skill: {skill_name}. Available: {available}")
+
+    module_path, class_name = SKILL_REGISTRY[skill_name].split(":")
+
+    # Dynamic import
+    from importlib import import_module
+
+    module = import_module(module_path)
+    tool_cls = getattr(module, class_name)
+
+    return tool_cls()
+
+
+async def execute_tool(tool, payload: dict, skill_name: str) -> tuple[str, bool]:
+    """
+    Execute a tool with the given payload.
+
+    This function uses shared entry point logic to ensure consistency with MCP server mode:
+    1. continuation_id handling (thread context reconstruction)
+    2. model:option parsing (e.g., model:for, model:against)
+    3. Model resolution (handles 'auto' mode)
+    4. ModelContext creation
+    5. File size validation
+
+    Args:
+        tool: The tool instance
+        payload: Input parameters dictionary
+        skill_name: Name of the skill being executed
+
+    Returns:
+        Tuple of (JSON string result, success boolean)
+        - success=True: Tool executed successfully
+        - success=False: Error occurred (caller should use non-zero exit code)
+    """
+    from utils.model_resolution import ModelResolutionError
+    from utils.tool_entry import FileSizeExceededError, prepare_tool_arguments
+
+    try:
+        # Use shared entry point logic (same as MCP server mode)
+        payload = await prepare_tool_arguments(tool, payload, skill_name)
+    except ModelResolutionError as e:
+        # Enhance error message with pal-listmodels hint
+        error_msg = str(e)
+        error_msg += "\n\nTip: Use `pal-listmodels` skill to see all available models."
+        return (
+            json.dumps(
+                {
+                    "status": "error",
+                    "content": error_msg,
+                    "content_type": "text",
+                    "metadata": {
+                        "available_models": e.available_models,
+                        "suggested_model": e.suggested_model,
+                        "hint": "Use pal-listmodels skill to see all available models",
+                    },
+                }
+            ),
+            False,
+        )
+    except FileSizeExceededError as e:
+        return json.dumps(e.error_response), False
+    except ValueError as e:
+        # Handle continuation_id errors
+        return (
+            json.dumps(
+                {
+                    "status": "error",
+                    "content": str(e),
+                    "content_type": "text",
+                }
+            ),
+            False,
+        )
+
+    result = await tool.execute(payload)
+
+    # Handle result and determine success status
+    # MCP mode returns list[TextContent] directly; Skills mode serializes to JSON
+    #
+    # Output format matches MCP mode behavior:
+    # - MCP mode: returns list[TextContent] via protocol
+    # - Skills mode: returns the .text content from TextContent (already JSON)
+    #
+    # All tools return list[TextContent] where .text contains the full JSON response.
+    # We extract .text directly to match what MCP clients receive after deserialization.
+
+    if not result:
+        return json.dumps({"status": "error", "content": "No response from tool"}), False
+
+    # Standard MCP return format: list[TextContent]
+    if isinstance(result, list) and len(result) > 0:
+        first_item = result[0]
+
+        # TextContent object with .text attribute
+        if hasattr(first_item, "text"):
+            text = first_item.text
+            success = not _is_error_response(text)
+            return text, success
+
+        # List of strings (rare case)
+        if isinstance(first_item, str):
+            success = not _is_error_response(first_item)
+            return first_item, success
+
+        # List of dicts (rare case)
+        if isinstance(first_item, dict):
+            success = first_item.get("status") != "error"
+            return json.dumps(first_item, ensure_ascii=False), success
+
+    # Direct string return (rare case)
+    if isinstance(result, str):
+        success = not _is_error_response(result)
+        return result, success
+
+    # Direct dict return (rare case)
+    if isinstance(result, dict):
+        success = result.get("status") != "error"
+        return json.dumps(result, ensure_ascii=False), success
+
+    # Other types - attempt JSON serialization
+    try:
+        return json.dumps(result, ensure_ascii=False), True
+    except (TypeError, ValueError):
+        return str(result), True
+
+
+def _is_error_response(text: str) -> bool:
+    """
+    Check if a text response indicates an error.
+
+    This is used to determine the exit code for Skills mode.
+    """
+    if not text:
+        return False
+    # Try to parse as JSON and check status
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict) and data.get("status") == "error":
+            return True
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return False
+
+
+# =============================================================================
+# Main Entry Point
+# =============================================================================
+
+
+def parse_dynamic_args(unknown_args: list) -> dict:
+    """
+    Parse unknown arguments into a dictionary.
+
+    Supports formats:
+    - --key value
+    - --key=value
+    - --flag (boolean True)
+
+    Args:
+        unknown_args: List of unparsed arguments
+
+    Returns:
+        Dictionary of parsed key-value pairs
+    """
+    result = {}
+    i = 0
+    while i < len(unknown_args):
+        arg = unknown_args[i]
+        if arg.startswith("--"):
+            key = arg[2:]  # Remove '--' prefix
+
+            # Handle --key=value format
+            if "=" in key:
+                key, value = key.split("=", 1)
+                result[key] = _parse_value(value)
+            # Handle --key value format
+            elif i + 1 < len(unknown_args) and not unknown_args[i + 1].startswith("--"):
+                result[key] = _parse_value(unknown_args[i + 1])
+                i += 1
+            # Handle --flag (boolean)
+            else:
+                result[key] = True
+        i += 1
+    return result
+
+
+def _parse_value(value: str):
+    """
+    Parse a string value into appropriate type.
+
+    Attempts to parse as JSON first (for arrays, objects, numbers, booleans),
+    falls back to string.
+    """
+    # Try parsing as JSON (handles arrays, objects, numbers, booleans)
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        pass
+
+    # Return as string
+    return value
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="PAL Skill Runner - Execute PAL tools directly",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --skill pal-chat --input '{"prompt": "Hello"}'
+  %(prog)s --skill pal-chat --prompt "Hello" --thinking_mode medium
+  echo '{"prompt": "Hello"}' | %(prog)s --skill pal-chat
+  %(prog)s --list
+        """,
+    )
+    parser.add_argument(
+        "--skill",
+        help="Skill name to execute (e.g., pal-chat, pal-codereview)",
+    )
+    parser.add_argument(
+        "--input",
+        help="JSON input string or path to JSON file",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List all available skills",
+    )
+
+    # Use parse_known_args to capture dynamic parameters
+    args, unknown_args = parser.parse_known_args()
+
+    # List skills mode
+    if args.list:
+        print("Available skills:")
+        for skill in sorted(SKILL_REGISTRY.keys()):
+            print(f"  - {skill}")
+        return
+
+    # Validate arguments
+    if not args.skill:
+        parser.error("--skill is required (or use --list to see available skills)")
+
+    try:
+        # Save original working directory before setup changes it
+        original_cwd = os.getcwd()
+        os.environ["SKILL_ORIGINAL_CWD"] = original_cwd
+
+        # Resolve project root
+        root = resolve_pal_root()
+
+        # Setup environment (load .env, configure providers)
+        setup_environment(root)
+
+        # Load input payload - supports multiple formats:
+        # 1. --input JSON (explicit JSON input)
+        # 2. Dynamic args (--prompt "..." --model "...")
+        # 3. stdin (piped JSON)
+        if args.input:
+            payload = load_payload(args.input)
+        elif unknown_args:
+            # Parse dynamic arguments into payload
+            payload = parse_dynamic_args(unknown_args)
+        else:
+            # Try stdin
+            payload = load_payload(None)
+
+        # Auto-fill common fields (e.g., working_directory_absolute_path)
+        payload = auto_fill_common_fields(payload, args.skill)
+
+        # Get tool instance
+        tool = get_tool_instance(args.skill)
+
+        # Execute and print result
+        result, success = asyncio.run(execute_tool(tool, payload, args.skill))
+        print(result)
+
+        # Exit with non-zero code on error (CLI best practice)
+        if not success:
+            sys.exit(1)
+
+    except json.JSONDecodeError as e:
+        error = {"status": "error", "content": f"Invalid JSON input: {e}"}
+        print(json.dumps(error))
+        sys.exit(1)
+    except ValueError as e:
+        error = {"status": "error", "content": str(e)}
+        print(json.dumps(error))
+        sys.exit(1)
+    except Exception as e:
+        error = {"status": "error", "content": f"Execution error: {e}"}
+        print(json.dumps(error))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills-optional/pal-analyze/SKILL.md
+++ b/skills-optional/pal-analyze/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: pal-analyze
+description: Analyzes complex codebases deeply, examining architecture, patterns, dependencies, and code structure.
+allowed-tools: Bash, Read
+---
+
+# PAL Analyze
+
+## Overview
+
+Comprehensive codebase analysis covering architecture, design patterns, and dependencies. Uses multi-step workflow for thorough investigation.
+
+## When to Use
+
+- Understanding unfamiliar codebases
+- Analyzing architectural patterns
+- Mapping dependencies between components
+- Identifying code structure issues
+
+## Workflow
+
+Multi-step analysis process:
+1. Define analysis strategy and scope
+2. Examine code structure
+3. Identify patterns and dependencies
+4. Synthesize findings
+5. Provide recommendations
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Analysis plan and current findings
+- `step_number` (integer): Current step number (starts at 1)
+- `total_steps` (integer): Estimated total steps
+- `next_step_required` (boolean): Whether more analysis needed
+- `findings` (string): Discoveries from this step
+
+### Optional
+- `files_checked` (string[]): Files examined (absolute paths)
+- `relevant_files` (string[]): Files relevant to findings (absolute paths)
+- `analysis_type` (string): architecture, performance, security, dependencies, etc.
+- `output_format` (string): summary, detailed, or actionable
+- `issues_found` (object[]): Issues with severity levels
+- `hypothesis` (string): Current theory
+- `confidence` (string): exploring, low, medium, high, very_high
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous analysis
+- `thinking_mode` (string): Reasoning depth
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use expert model for analysis
+- `images` (string[]): Architecture diagrams or visuals
+
+## Output
+
+JSON with analysis findings, architectural insights, and recommendations.
+
+## Invocation
+
+```bash
+# Start analysis (step 1)
+pal-analyze --step "Analyze codebase architecture" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue analysis (step 2+)
+pal-analyze --step "Examine dependencies" --step_number 2 --total_steps 4 --next_step_required true --findings "Found MVC pattern" --continuation_id "abc-123"
+
+# With specific analysis type
+pal-analyze --step "Security analysis" --step_number 1 --total_steps 3 --next_step_required true --findings "" --analysis_type security --relevant_files '["./src/auth.py"]'
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-analyze/run.sh
+++ b/skills-optional/pal-analyze/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills-optional/pal-docgen/SKILL.md
+++ b/skills-optional/pal-docgen/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: pal-docgen
+description: Generates documentation including docstrings, README files, and API documentation for code.
+allowed-tools: Bash, Read
+---
+
+# PAL DocGen
+
+## Overview
+
+Generate comprehensive documentation including docstrings, README files, and API documentation. Uses multi-step workflow to document code systematically.
+
+## When to Use
+
+- Adding documentation to code
+- Creating README files
+- Generating API docs
+- Improving code documentation
+
+## Workflow
+
+Multi-step documentation generation:
+1. Analyze code structure and purpose
+2. Document functions and classes
+3. Generate README or API docs
+4. Add inline comments for complex logic
+5. Review and finalize
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Documentation plan and current progress
+- `step_number` (integer): Current step number (starts at 1)
+- `total_steps` (integer): Estimated total steps
+- `next_step_required` (boolean): Whether more documentation needed
+- `findings` (string): Documentation insights and progress
+- `num_files_documented` (integer): Files documented so far
+- `total_files_to_document` (integer): Total files to document
+- `update_existing` (boolean): Polish existing docs (default: true)
+- `document_flow` (boolean): Include call flow notes (default: true)
+- `document_complexity` (boolean): Include Big O analysis (default: true)
+- `comments_on_complex_logic` (boolean): Add inline comments (default: true)
+
+### Optional
+- `relevant_files` (string[]): Files to document (absolute paths)
+- `issues_found` (object[]): Documentation issues with severity
+- `continuation_id` (string): Continue previous documentation
+- `use_assistant_model` (boolean): Use expert model for analysis
+
+## Output
+
+JSON with generated documentation content and formatting suggestions.
+
+## Invocation
+
+```bash
+# Start documentation (step 1)
+pal-docgen --step "Analyze code structure" --step_number 1 --total_steps 4 --next_step_required true --findings "" --num_files_documented 0 --total_files_to_document 5 --relevant_files '["./src/main.py"]'
+
+# Continue documentation (step 2+)
+pal-docgen --step "Document functions" --step_number 2 --total_steps 4 --next_step_required true --findings "Found 10 functions" --num_files_documented 1 --total_files_to_document 5 --continuation_id "abc-123"
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-docgen/run.sh
+++ b/skills-optional/pal-docgen/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills-optional/pal-refactor/SKILL.md
+++ b/skills-optional/pal-refactor/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pal-refactor
+description: Identifies refactoring opportunities and code smells, suggesting improvements for cleaner, more maintainable code.
+allowed-tools: Bash, Read
+---
+
+# PAL Refactor
+
+## Overview
+
+Identify code smells and refactoring opportunities. Uses multi-step workflow to analyze code and provide actionable improvement suggestions.
+
+## When to Use
+
+- Improving code quality
+- Reducing technical debt
+- Identifying code smells
+- Planning refactoring efforts
+
+## Workflow
+
+Multi-step refactoring analysis:
+1. Define refactoring strategy
+2. Identify code smells
+3. Analyze impact and dependencies
+4. Generate refactoring suggestions
+5. Prioritize recommendations
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Refactoring plan and current findings
+- `step_number` (integer): Current step number (starts at 1)
+- `total_steps` (integer): Estimated total steps
+- `next_step_required` (boolean): Whether more analysis needed
+- `findings` (string): Code smells and opportunities found
+
+### Optional
+- `files_checked` (string[]): Files examined (absolute paths)
+- `relevant_files` (string[]): Files needing refactoring (absolute paths)
+- `refactor_type` (string): codesmells, decompose, extract, rename, simplify
+- `focus_areas` (string[]): performance, readability, maintainability, etc.
+- `style_guide_examples` (string[]): Files to use as style reference
+- `issues_found` (object[]): Opportunities with severity and suggestions
+- `hypothesis` (string): Current theory
+- `confidence` (string): exploring, low, medium, high, very_high
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous analysis
+- `thinking_mode` (string): Reasoning depth
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use expert model for analysis
+- `images` (string[]): Architecture diagrams or visuals
+
+## Output
+
+JSON with identified code smells, refactoring suggestions, and priority recommendations.
+
+## Invocation
+
+```bash
+# Start refactoring analysis (step 1)
+pal-refactor --step "Identify code smells" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue analysis (step 2+)
+pal-refactor --step "Analyze impact" --step_number 2 --total_steps 4 --next_step_required true --findings "Found duplicate code" --continuation_id "abc-123"
+
+# With specific refactor type
+pal-refactor --step "Find extraction opportunities" --step_number 1 --total_steps 3 --next_step_required true --findings "" --refactor_type extract --relevant_files '["./src/utils.py"]'
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-refactor/run.sh
+++ b/skills-optional/pal-refactor/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills-optional/pal-secaudit/SKILL.md
+++ b/skills-optional/pal-secaudit/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: pal-secaudit
+description: Performs security audit and vulnerability analysis, identifying security issues, OWASP risks, and secure coding violations.
+allowed-tools: Bash, Read
+---
+
+# PAL SecAudit
+
+## Overview
+
+Security-focused code analysis identifying vulnerabilities, OWASP risks, and secure coding violations. Uses multi-step workflow for thorough security review.
+
+## When to Use
+
+- Security code reviews
+- Vulnerability assessment
+- OWASP compliance checking
+- Pre-deployment security validation
+
+## Workflow
+
+Multi-step security audit:
+1. Define audit strategy (OWASP Top 10, auth, validation)
+2. Analyze authentication and authorization
+3. Check input validation and injection risks
+4. Review data handling and encryption
+5. Final security assessment
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Audit strategy and current findings
+- `step_number` (integer): Current step number (starts at 1)
+- `total_steps` (integer): Estimated total steps
+- `next_step_required` (boolean): Whether more analysis needed
+- `findings` (string): Vulnerabilities, auth issues, validation gaps
+
+### Optional
+- `files_checked` (string[]): Files inspected (absolute paths)
+- `relevant_files` (string[]): Security-relevant files (absolute paths)
+- `audit_focus` (string): owasp, compliance, infrastructure, dependencies
+- `security_scope` (string): web, mobile, API, cloud
+- `compliance_requirements` (string[]): SOC2, PCI DSS, HIPAA, etc.
+- `threat_level` (string): low, medium, high
+- `severity_filter` (string): Minimum severity to report
+- `issues_found` (object[]): Vulnerabilities with severity
+- `hypothesis` (string): Current theory about risks
+- `confidence` (string): exploring, low, medium, high, very_high
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous audit
+- `thinking_mode` (string): Reasoning depth
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use expert model for analysis
+- `images` (string[]): Diagrams or threat models
+
+## Output
+
+JSON with vulnerabilities found, severity levels, and remediation steps.
+
+## Invocation
+
+```bash
+# Start security audit (step 1)
+pal-secaudit --step "Define audit strategy" --step_number 1 --total_steps 5 --next_step_required true --findings ""
+
+# Continue audit (step 2+)
+pal-secaudit --step "Check authentication" --step_number 2 --total_steps 5 --next_step_required true --findings "JWT implementation found" --continuation_id "abc-123"
+
+# With specific focus
+pal-secaudit --step "OWASP Top 10 review" --step_number 1 --total_steps 4 --next_step_required true --findings "" --audit_focus owasp --relevant_files '["./src/api.py"]'
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-secaudit/run.sh
+++ b/skills-optional/pal-secaudit/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills-optional/pal-testgen/SKILL.md
+++ b/skills-optional/pal-testgen/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pal-testgen
+description: Generates test cases including unit tests, integration tests, and test scenarios for code coverage.
+allowed-tools: Bash, Read
+---
+
+# PAL TestGen
+
+## Overview
+
+Generate comprehensive test cases including unit tests, integration tests, and edge case scenarios. Uses multi-step workflow for thorough test planning.
+
+## When to Use
+
+- Creating tests for new code
+- Improving test coverage
+- Generating edge case tests
+- Writing integration tests
+
+## Workflow
+
+Multi-step test generation:
+1. Analyze code functionality
+2. Identify test scenarios
+3. Plan edge cases and boundaries
+4. Generate test code
+5. Review coverage
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Test plan and current findings
+- `step_number` (integer): Current step number (starts at 1)
+- `total_steps` (integer): Estimated total steps
+- `next_step_required` (boolean): Whether more planning needed
+- `findings` (string): Functionality, critical paths, edge cases
+
+### Optional
+- `files_checked` (string[]): Files examined (absolute paths)
+- `relevant_files` (string[]): Code that needs tests (absolute paths)
+- `issues_found` (object[]): Testing concerns with severity
+- `hypothesis` (string): Current theory about coverage gaps
+- `confidence` (string): exploring, low, medium, high, very_high
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous planning
+- `thinking_mode` (string): Reasoning depth
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use expert model for analysis
+- `images` (string[]): Diagrams clarifying test scenarios
+
+## Output
+
+JSON with generated test code, test scenarios, and coverage recommendations.
+
+## Invocation
+
+```bash
+# Start test generation (step 1)
+pal-testgen --step "Analyze code functionality" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue (step 2+)
+pal-testgen --step "Identify edge cases" --step_number 2 --total_steps 4 --next_step_required true --findings "Found 5 public methods" --continuation_id "abc-123"
+
+# With file context
+pal-testgen --step "Generate unit tests" --step_number 1 --total_steps 3 --next_step_required true --findings "" --relevant_files '["./src/calculator.py"]'
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-testgen/run.sh
+++ b/skills-optional/pal-testgen/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills-optional/pal-tracer/SKILL.md
+++ b/skills-optional/pal-tracer/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: pal-tracer
+description: Traces code execution and analyzes flow, mapping function calls, data transformations, and execution paths.
+allowed-tools: Bash, Read
+---
+
+# PAL Tracer
+
+## Overview
+
+Trace code execution paths, function calls, and data flow. Uses multi-step workflow to map how code executes and data transforms.
+
+## When to Use
+
+- Understanding execution flow
+- Tracing data transformations
+- Debugging complex call chains
+- Mapping function dependencies
+
+## Workflow
+
+Multi-step tracing process:
+1. Define tracing target and mode
+2. Map initial call structure
+3. Trace data flow
+4. Identify transformations
+5. Synthesize execution path
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Tracing plan and current findings
+- `step_number` (integer): Current step number (starts at 1)
+- `total_steps` (integer): Estimated total steps
+- `next_step_required` (boolean): Whether more tracing needed
+- `findings` (string): Call chains, data flow, execution paths
+- `target_description` (string): What to trace and WHY
+- `trace_mode` (string): ask (prompts user), static, dynamic, hybrid, data_flow
+
+### Optional
+- `files_checked` (string[]): Files examined (absolute paths)
+- `relevant_files` (string[]): Files in the execution path (absolute paths)
+- `hypothesis` (string): Current theory about flow
+- `confidence` (string): exploring, low, medium, high, very_high
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous tracing
+- `thinking_mode` (string): Reasoning depth
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use expert model for analysis
+- `images` (string[]): Flow charts or architecture diagrams
+
+## Output
+
+JSON with execution trace, call graph, and data flow analysis.
+
+## Invocation
+
+```bash
+# Start tracing (step 1)
+pal-tracer --step "Map call structure" --step_number 1 --total_steps 4 --next_step_required true --findings "" --target_description "Trace user login flow" --trace_mode static
+
+# Continue tracing (step 2+)
+pal-tracer --step "Trace data flow" --step_number 2 --total_steps 4 --next_step_required true --findings "Entry point: login()" --target_description "Trace user login flow" --trace_mode static --continuation_id "abc-123"
+
+# With file context
+pal-tracer --step "Analyze execution path" --step_number 1 --total_steps 3 --next_step_required true --findings "" --target_description "Order processing" --trace_mode data_flow --relevant_files '["./src/order.py"]'
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills-optional/pal-tracer/run.sh
+++ b/skills-optional/pal-tracer/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-apilookup/SKILL.md
+++ b/skills/pal-apilookup/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: pal-apilookup
+description: Searches API and SDK documentation for current references, usage examples, and best practices.
+allowed-tools: Bash, Read
+---
+
+# PAL API Lookup
+
+## Overview
+
+Search and retrieve API documentation, SDK usage examples, and best practices. Gets up-to-date information from official sources.
+
+## When to Use
+
+- Looking up API usage patterns
+- Finding SDK documentation
+- Checking library best practices
+- Understanding API changes
+
+## Parameters
+
+### Required
+- `prompt` (string): What API/SDK information you need
+
+### Optional
+None - this is a simple single-prompt tool.
+
+## Output
+
+JSON with documentation excerpts, usage examples, and relevant links.
+
+## Invocation
+
+```bash
+# Basic usage
+pal-apilookup --prompt "How to use React useEffect hook?"
+
+# SDK documentation
+pal-apilookup --prompt "Python requests library POST with JSON body"
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-apilookup/run.sh
+++ b/skills/pal-apilookup/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-challenge/SKILL.md
+++ b/skills/pal-challenge/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: pal-challenge
+description: Provides critical thinking and assumption challenging, questioning decisions, surfacing blind spots, and offering counter-arguments for better solutions.
+allowed-tools: Bash, Read
+---
+
+# PAL Challenge
+
+## Overview
+
+Devil's advocate analysis that questions assumptions and provides counter-arguments. Helps identify blind spots and strengthen decisions.
+
+## When to Use
+
+- Validating important decisions
+- Stress-testing proposed solutions
+- Identifying hidden assumptions
+- Getting constructive criticism
+
+## Parameters
+
+### Required
+- `prompt` (string): The decision or approach to challenge
+
+### Optional
+None - this is a simple single-prompt tool.
+
+## Output
+
+JSON with challenges, counter-arguments, identified risks, and alternative perspectives.
+
+## Invocation
+
+```bash
+# Challenge a decision
+pal-challenge --prompt "We decided to use microservices. What could go wrong?"
+
+# Stress-test an approach
+pal-challenge --prompt "Is using MongoDB for this use case a good idea?"
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-challenge/run.sh
+++ b/skills/pal-challenge/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-chat/SKILL.md
+++ b/skills/pal-chat/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: pal-chat
+description: Provides multi-model collaborative chat for brainstorming, development discussions, getting second opinions, and exploring ideas with AI assistance.
+allowed-tools: Bash, Read
+---
+
+# PAL Chat
+
+## Overview
+
+Collaborative thinking and development discussions with PAL's multi-model AI support. Maintains conversation context across multiple exchanges.
+
+## When to Use
+
+- Brainstorming ideas or approaches
+- Getting a second opinion on technical decisions
+- Discussing code architecture or design patterns
+- Exploring solutions to complex problems
+
+## Parameters
+
+### Required
+- `prompt` (string): Your question or topic for discussion
+
+### Optional
+- `absolute_file_paths` (string[]): Full absolute paths to code files for context
+- `images` (string[]): Image paths (absolute) or base64 strings for visual context
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue a previous conversation
+- `thinking_mode` (string): Reasoning depth - minimal, low, medium, high, or max
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `working_directory_absolute_path` (string): Working directory (auto-filled if omitted)
+
+## Output
+
+JSON response with AI analysis and optional `continuation_id` for follow-up conversations.
+
+## Invocation
+
+```bash
+# Basic usage
+pal-chat --prompt "How should I structure this API?"
+
+# With file context
+pal-chat --prompt "Review this code" --absolute_file_paths '["./src/main.py"]'
+
+# Continue conversation
+pal-chat --prompt "Tell me more" --continuation_id "abc-123"
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-chat/run.sh
+++ b/skills/pal-chat/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-clink/SKILL.md
+++ b/skills/pal-clink/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: pal-clink
+description: Bridges to external AI CLIs like Gemini CLI, enabling cross-model collaboration and specialized external capabilities.
+allowed-tools: Bash, Read
+---
+
+# PAL CLink
+
+## Overview
+
+Connect to external AI command-line tools for cross-model collaboration. Enables leveraging specialized capabilities from other AI systems.
+
+## When to Use
+
+- Cross-model verification
+- Accessing specialized AI capabilities
+- Getting diverse AI perspectives
+- Leveraging external AI tools
+
+## Parameters
+
+### Required
+- `cli_name` (string): CLI client name from conf/cli_clients (e.g., gemini, aider)
+- `prompt` (string): Query for the external AI
+
+### Optional
+- `absolute_file_paths` (string[]): Full paths to relevant code files
+- `images` (string[]): Image paths or base64 for visual context
+- `continuation_id` (string): Continue a previous conversation
+- `role` (string): Role preset defined for the selected CLI
+
+## Output
+
+JSON with external AI response and integration notes.
+
+## Invocation
+
+```bash
+# Call Gemini CLI
+pal-clink --cli_name gemini --prompt "Analyze this architecture"
+
+# Call Codex CLI
+pal-clink --cli_name codex --prompt "Review this code"
+
+# With file context
+pal-clink --cli_name gemini --prompt "Explain this" --absolute_file_paths '["./src/main.py"]'
+
+# Continue conversation
+pal-clink --cli_name gemini --prompt "More details" --continuation_id "abc-123"
+```
+
+## Model Selection
+
+CLink uses external CLI tools (Gemini CLI, aider, etc.) rather than internal PAL models.
+Use `pal-listmodels` to see available internal models for other PAL skills.

--- a/skills/pal-clink/run.sh
+++ b/skills/pal-clink/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-codereview/SKILL.md
+++ b/skills/pal-codereview/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pal-codereview
+description: Performs systematic code review with multi-step workflow, analyzing code quality, security, performance, and best practices.
+allowed-tools: Bash, Read
+---
+
+# PAL Code Review
+
+## Overview
+
+Multi-step systematic code review covering quality, security, performance, and maintainability. Provides actionable findings with severity levels.
+
+## When to Use
+
+- Before merging pull requests
+- Reviewing new code additions
+- Security and vulnerability assessment
+- Performance optimization analysis
+
+## Workflow
+
+Multi-step review process:
+1. Initial code structure analysis
+2. Security vulnerability scan
+3. Performance assessment
+4. Best practices review
+5. Final summary with recommendations
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Review narrative describing current step
+- `step_number` (integer): Current review step (starts at 1)
+- `total_steps` (integer): Number of review steps planned
+- `next_step_required` (boolean): True when another review step follows
+- `findings` (string): Findings across quality, security, performance
+
+### Optional
+- `relevant_files` (string[]): Files under review (absolute paths, required in step 1)
+- `files_checked` (string[]): Files reviewed, including ruled-out ones (absolute paths)
+- `issues_found` (object[]): Issues with severity (critical/high/medium/low)
+- `review_type` (string): full, security, performance, or quick
+- `focus_on` (string): Areas to emphasize (e.g., 'threading', 'auth')
+- `standards` (string[]): Coding standards or style guides to enforce
+- `severity_filter` (string): Minimum severity to report
+- `hypothesis` (string): Current theory about issues
+- `confidence` (string): exploring, low, medium, high, very_high
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous review
+- `thinking_mode` (string): Reasoning depth
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use expert model for validation
+
+## Output
+
+JSON with review findings, severity levels, and guidance for next steps.
+
+## Invocation
+
+```bash
+# Start code review (step 1)
+pal-codereview --step "Initial code structure analysis" --step_number 1 --total_steps 5 --next_step_required true --findings "" --relevant_files '["./src/api.py"]'
+
+# Continue review (step 2+)
+pal-codereview --step "Security scan" --step_number 2 --total_steps 5 --next_step_required true --findings "Found input validation" --continuation_id "abc-123"
+
+# With specific focus
+pal-codereview --step "Performance review" --step_number 1 --total_steps 3 --next_step_required true --findings "" --review_type performance --focus_on "database queries"
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-codereview/run.sh
+++ b/skills/pal-codereview/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-consensus/SKILL.md
+++ b/skills/pal-consensus/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: pal-consensus
+description: Builds consensus using multiple AI models for important decisions, providing diverse perspectives to reach balanced conclusions.
+allowed-tools: Bash, Read
+---
+
+# PAL Consensus
+
+## Overview
+
+Get perspectives from multiple AI models to build consensus on important decisions. Uses a workflow to consult each model and synthesize findings.
+
+## When to Use
+
+- Critical architectural decisions
+- Evaluating competing approaches
+- Risk assessment for major changes
+- When diverse perspectives are valuable
+
+## Workflow
+
+Multi-step consensus process:
+1. Your independent analysis
+2. Consult model 1
+3. Consult model 2
+4. ... (continue for each model)
+5. Final synthesis
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Step 1 is your analysis; later steps consult models
+- `step_number` (integer): Current step index (starts at 1)
+- `total_steps` (integer): Number of models plus final synthesis
+- `next_step_required` (boolean): True if more consultations remain
+- `findings` (string): Step 1 is your analysis for later synthesis
+
+### Optional
+- `models` (string[]): Models to consult (provide at least 2)
+- `relevant_files` (string[]): Supporting files (absolute paths)
+- `images` (string[]): Visual context (absolute paths or base64)
+- `current_model_index` (integer): Internal tracking
+- `model_responses` (object[]): Internal log of responses
+- `continuation_id` (string): Continue previous consensus
+- `use_assistant_model` (boolean): Use expert model for synthesis
+
+## Output
+
+JSON with multi-model analysis, areas of agreement, disagreements, and synthesized recommendation.
+
+## Invocation
+
+```bash
+# Start consensus (step 1 - your analysis)
+pal-consensus --step "Evaluate REST vs GraphQL for our API" --step_number 1 --total_steps 4 --next_step_required true --findings "Initial analysis: REST is simpler but GraphQL offers flexibility" --models '["gemini-2.5-pro", "gpt-4o"]'
+
+# Continue (step 2+ - consult models)
+pal-consensus --step "Consulting model 1" --step_number 2 --total_steps 4 --next_step_required true --findings "" --continuation_id "abc-123"
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Provide `models` array to specify which models to consult for consensus
+- Use `pal-listmodels` to see available model names first

--- a/skills/pal-consensus/run.sh
+++ b/skills/pal-consensus/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-debug/SKILL.md
+++ b/skills/pal-debug/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pal-debug
+description: Performs systematic debugging and root cause analysis, identifying and fixing bugs through structured investigation.
+allowed-tools: Bash, Read
+---
+
+# PAL Debug
+
+## Overview
+
+Structured debugging workflow for identifying root causes. Uses systematic investigation to track down and resolve issues.
+
+## When to Use
+
+- Investigating unexpected behavior
+- Tracking down elusive bugs
+- Understanding error patterns
+- Root cause analysis
+
+## Workflow
+
+Multi-step debugging process:
+1. Reproduce and document the issue
+2. Gather relevant context and logs
+3. Form hypotheses
+4. Test and eliminate possibilities
+5. Identify root cause and solution
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Investigation step description
+- `step_number` (integer): Current step index (starts at 1)
+- `total_steps` (integer): Estimated total investigation steps
+- `next_step_required` (boolean): True if more investigation needed
+- `findings` (string): Clues, evidence, disproven theories
+
+### Optional
+- `files_checked` (string[]): All examined files (absolute paths)
+- `relevant_files` (string[]): Files directly relevant to issue (absolute paths)
+- `hypothesis` (string): Concrete root cause theory from evidence
+- `confidence` (string): exploring, low, medium, high, very_high, almost_certain, certain
+- `issues_found` (object[]): Issues with severity levels
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous investigation
+- `thinking_mode` (string): Reasoning depth
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use expert model for analysis
+- `images` (string[]): Screenshots/visuals clarifying the issue
+
+## Output
+
+JSON with debugging findings, hypotheses, and recommended fixes.
+
+## Invocation
+
+```bash
+# Start debugging (step 1)
+pal-debug --step "Reproduce the null pointer exception" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue investigation (step 2+)
+pal-debug --step "Trace data flow" --step_number 2 --total_steps 4 --next_step_required true --findings "Exception occurs in processOrder()" --hypothesis "Input validation missing" --continuation_id "abc-123"
+
+# With file context
+pal-debug --step "Analyze error logs" --step_number 1 --total_steps 3 --next_step_required true --findings "" --relevant_files '["./src/order.py", "./logs/error.log"]'
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-debug/run.sh
+++ b/skills/pal-debug/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-listmodels/SKILL.md
+++ b/skills/pal-listmodels/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: pal-listmodels
+description: Lists all available AI models configured for PAL tools, showing providers, model names, aliases, and capabilities.
+allowed-tools: Bash, Read
+---
+
+# PAL List Models
+
+## Overview
+
+Query available AI models for PAL tools. Shows which providers are configured (Google Gemini, OpenAI, OpenRouter, etc.) and what models can be used.
+
+## When to Use
+
+- Before using other PAL tools, to see what models are available
+- To check if a specific model or provider is configured
+- To understand model capabilities (context window, thinking support)
+- To troubleshoot model selection issues
+
+## Parameters
+
+This skill takes no parameters - it automatically detects configured providers.
+
+## Output
+
+JSON response with:
+- List of configured providers and their status
+- Available models organized by provider
+- Model aliases and their canonical names
+- Context window sizes and capabilities
+- Total count of available models
+
+## Example Output
+
+```json
+{
+  "status": "success",
+  "content": "# Available AI Models\n\n## Google Gemini ✅\n...",
+  "metadata": {
+    "configured_providers": 3
+  }
+}
+```
+
+## Invocation
+
+```bash
+# List all available models (no parameters needed)
+pal-listmodels
+```
+
+## Notes
+
+- Models are detected at runtime based on your `.env` configuration
+- Use `pal-listmodels` before other skills to verify model availability
+- Model restrictions (if configured) are reflected in the output

--- a/skills/pal-listmodels/run.sh
+++ b/skills/pal-listmodels/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-planner/SKILL.md
+++ b/skills/pal-planner/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: pal-planner
+description: Creates detailed implementation plans with step-by-step workflow for features, refactoring, and architectural changes.
+allowed-tools: Bash, Read
+---
+
+# PAL Planner
+
+## Overview
+
+Create detailed implementation plans for complex tasks. Breaks down features, refactoring efforts, or architectural changes into actionable steps.
+
+## When to Use
+
+- Planning new feature implementation
+- Designing refactoring strategies
+- Architectural change planning
+- Breaking down complex tasks
+
+## Workflow
+
+Multi-step planning workflow:
+1. Analyze requirements and constraints
+2. Identify affected components
+3. Design implementation approach
+4. Create step-by-step action plan
+5. Define validation criteria
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Current planning step description
+- `step_number` (integer): Current step number (starts at 1)
+- `total_steps` (integer): Total planned steps
+- `next_step_required` (boolean): Whether more steps needed
+
+### Optional
+- `branch_id` (string): Name for this branch (e.g., 'approach-A')
+- `branch_from_step` (integer): Step number that this branch starts from
+- `is_branch_point` (boolean): True when creating a new branch
+- `is_step_revision` (boolean): True when replacing a previous step
+- `revises_step_number` (integer): Step number being replaced
+- `more_steps_needed` (boolean): True when expecting additional steps
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous planning
+- `use_assistant_model` (boolean): Use expert model for analysis
+
+## Output
+
+JSON with implementation plan, dependencies, and recommended execution order.
+
+## Invocation
+
+```bash
+# Start planning (step 1)
+pal-planner --step "Analyze requirements for user auth feature" --step_number 1 --total_steps 5 --next_step_required true
+
+# Continue planning (step 2+)
+pal-planner --step "Design database schema" --step_number 2 --total_steps 5 --next_step_required true --continuation_id "abc-123"
+
+# Create alternative branch
+pal-planner --step "Alternative: OAuth approach" --step_number 3 --total_steps 5 --next_step_required true --branch_id "oauth-approach" --is_branch_point true
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-planner/run.sh
+++ b/skills/pal-planner/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-precommit/SKILL.md
+++ b/skills/pal-precommit/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pal-precommit
+description: Validates git changes before commit, reviewing staged modifications to catch issues early.
+allowed-tools: Bash, Read
+---
+
+# PAL Precommit
+
+## Overview
+
+Review staged git changes before committing. Multi-step workflow to validate code quality and ensure changes are ready for commit.
+
+## When to Use
+
+- Before committing changes
+- Validating staged modifications
+- Quick sanity check on changes
+- Ensuring commit readiness
+
+## Workflow
+
+Multi-step validation process:
+1. Outline validation strategy
+2. Review changes for issues
+3. Expert validation (optional)
+4. Final assessment
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Current validation step description
+- `step_number` (integer): Current pre-commit step number (starts at 1)
+- `total_steps` (integer): Planned number of validation steps
+- `next_step_required` (boolean): True to continue, False when done
+- `findings` (string): Git diff insights, risks, missing tests, etc.
+
+### Optional
+- `path` (string): Absolute path to repository root (required in step 1)
+- `compare_to` (string): Git ref to diff against (default: HEAD)
+- `include_staged` (boolean): Inspect staged changes
+- `include_unstaged` (boolean): Inspect unstaged changes
+- `files_checked` (string[]): Files examined (absolute paths)
+- `relevant_files` (string[]): Files involved in the change (absolute paths)
+- `issues_found` (object[]): Issues with severity (critical/high/medium/low)
+- `focus_on` (string): Areas to emphasize (security, performance, tests)
+- `severity_filter` (string): Minimum severity to report
+- `precommit_type` (string): 'external' (expert model) or 'internal'
+- `hypothesis` (string): Current theory about issues
+- `confidence` (string): exploring, low, medium, high, very_high
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous validation
+- `thinking_mode` (string): Reasoning depth
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use expert model for validation
+- `images` (string[]): Screenshots or diagrams
+
+## Output
+
+JSON with validation results, issues found, and commit readiness assessment.
+
+## Invocation
+
+```bash
+# Start validation (step 1)
+pal-precommit --step "Review staged changes" --step_number 1 --total_steps 3 --next_step_required true --findings "" --path "/path/to/repo"
+
+# Continue validation (step 2+)
+pal-precommit --step "Check for security issues" --step_number 2 --total_steps 3 --next_step_required true --findings "Found 3 modified files" --continuation_id "abc-123"
+
+# With focus area
+pal-precommit --step "Validate changes" --step_number 1 --total_steps 2 --next_step_required true --findings "" --path "/path/to/repo" --focus_on "security"
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-precommit/run.sh
+++ b/skills/pal-precommit/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/skills/pal-thinkdeep/SKILL.md
+++ b/skills/pal-thinkdeep/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pal-thinkdeep
+description: Provides deep analysis and extended reasoning for thorough exploration, multi-step reasoning, and comprehensive analysis of complex problems.
+allowed-tools: Bash, Read
+---
+
+# PAL ThinkDeep
+
+## Overview
+
+Extended reasoning for complex problems requiring deep analysis. Uses a multi-step workflow with forced pauses between steps for thorough investigation.
+
+## When to Use
+
+- Complex architectural decisions
+- Debugging difficult or mysterious issues
+- Analyzing trade-offs between approaches
+- Understanding intricate system behaviors
+
+## Workflow
+
+Multi-step deep thinking process:
+1. Define the problem and analysis approach
+2. Gather and analyze relevant context
+3. Form and test hypotheses
+4. Synthesize findings
+5. Draw conclusions with evidence
+
+## Parameters
+
+### Required (Workflow Fields)
+- `step` (string): Current work step content and findings
+- `step_number` (integer): Current step number (starts at 1)
+- `total_steps` (integer): Estimated total steps needed
+- `next_step_required` (boolean): Whether another step is needed
+- `findings` (string): Discoveries, insights, and evidence from this step
+
+### Optional
+- `files_checked` (string[]): Files examined during this step (absolute paths)
+- `relevant_files` (string[]): Files directly relevant to analysis (absolute paths)
+- `focus_areas` (string[]): Aspects to focus on (architecture, performance, security, etc.)
+- `hypothesis` (string): Current theory based on work
+- `confidence` (string): exploring, low, medium, high, very_high, almost_certain, certain
+- `issues_found` (object[]): Issues with severity levels
+- `model` (string): Specific model to use (default: auto-select)
+- `continuation_id` (string): Continue previous analysis
+- `thinking_mode` (string): Reasoning depth (default: high for thinkdeep)
+- `temperature` (number): 0 = deterministic, 1 = creative
+- `use_assistant_model` (boolean): Use assistant model for expert analysis
+
+## Output
+
+JSON response with deep analysis results, findings, and workflow continuation guidance.
+
+## Invocation
+
+```bash
+# Start deep analysis (step 1)
+pal-thinkdeep --step "Analyze the authentication flow" --step_number 1 --total_steps 4 --next_step_required true --findings ""
+
+# Continue analysis (step 2+)
+pal-thinkdeep --step "Examine token validation" --step_number 2 --total_steps 4 --next_step_required true --findings "Found JWT implementation" --continuation_id "abc-123"
+
+# With file context
+pal-thinkdeep --step "Review architecture" --step_number 1 --total_steps 3 --next_step_required true --findings "" --relevant_files '["./src/auth.py"]'
+```
+
+## Model Selection
+
+- Default: auto - System automatically selects the best available model
+- Do NOT specify `--model` unless you have a specific reason - let the system choose
+- If you must specify, use `pal-listmodels` to see available model names first

--- a/skills/pal-thinkdeep/run.sh
+++ b/skills/pal-thinkdeep/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the directory where this script is located (resolving symlinks)
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+SKILL_NAME="$(basename "${SCRIPT_DIR}")"
+
+# Read PAL_MCP_ROOT from config file if exists (installed mode)
+CONFIG_FILE="${SCRIPT_DIR}/scripts/.pal_config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    PAL_MCP_ROOT="$(sed -n 's/^PAL_MCP_ROOT="\([^"]*\)".*/\1/p' "$CONFIG_FILE" 2>/dev/null || true)"
+    if [[ -n "$PAL_MCP_ROOT" ]]; then
+        export PAL_MCP_SERVER_ROOT="$PAL_MCP_ROOT"
+    fi
+fi
+
+# Find the runner script
+# Priority: 1) config-based path, 2) installed location, 3) development locations (up to 4 levels)
+find_runner() {
+    # 1) Use PAL_MCP_ROOT if available (from .pal_config or environment)
+    if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -f "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py" ]]; then
+        echo "${PAL_MCP_SERVER_ROOT}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 2) Check installed location (runner copied to skill directory)
+    if [[ -f "${SCRIPT_DIR}/scripts/pal_skill_runner.py" ]]; then
+        echo "${SCRIPT_DIR}/scripts/pal_skill_runner.py"
+        return 0
+    fi
+
+    # 3) Search upward for development locations (skills/, skills-optional/, etc.)
+    local current="${SCRIPT_DIR}"
+    for _ in {1..4}; do
+        current="$(dirname "$current")"
+        if [[ -f "$current/scripts/pal_skill_runner.py" ]]; then
+            echo "$current/scripts/pal_skill_runner.py"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+RUNNER="$(find_runner)" || {
+    echo "Error: pal_skill_runner.py not found" >&2
+    echo "Searched: config path, ${SCRIPT_DIR}/scripts/, and up to 4 parent directories" >&2
+    echo "Tip: Run from pal-mcp-server repo or execute ./install-skills.sh first" >&2
+    exit 1
+}
+
+# Determine Python executable
+if [[ -n "${PAL_MCP_SERVER_ROOT:-}" ]] && [[ -x "$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python" ]]; then
+    PYTHON_BIN="$PAL_MCP_SERVER_ROOT/.pal_venv/bin/python"
+else
+    PYTHON_BIN="$(command -v python3 || command -v python)"
+fi
+
+# Execute the runner with the skill name and pass all arguments
+exec "$PYTHON_BIN" "$RUNNER" --skill "$SKILL_NAME" "$@"

--- a/utils/follow_up.py
+++ b/utils/follow_up.py
@@ -1,0 +1,60 @@
+"""
+Follow-up instructions for conversation continuation.
+
+This module provides functions for generating dynamic follow-up instructions
+based on conversation turn count. It's separated from server.py to avoid
+triggering MCP server initialization when imported.
+"""
+
+
+def get_follow_up_instructions(current_turn_count: int, max_turns: int = None) -> str:
+    """
+    Generate dynamic follow-up instructions based on conversation turn count.
+
+    Args:
+        current_turn_count: Current number of turns in the conversation
+        max_turns: Maximum allowed turns before conversation ends (defaults to MAX_CONVERSATION_TURNS)
+
+    Returns:
+        Follow-up instructions to append to the tool prompt
+    """
+    if max_turns is None:
+        from utils.conversation_memory import MAX_CONVERSATION_TURNS
+
+        max_turns = MAX_CONVERSATION_TURNS
+
+    if current_turn_count >= max_turns - 1:
+        # We're at or approaching the turn limit - no more follow-ups
+        return """
+IMPORTANT: This is approaching the final exchange in this conversation thread.
+Do NOT include any follow-up questions in your response. Provide your complete
+final analysis and recommendations."""
+    else:
+        # Normal follow-up instructions
+        remaining_turns = max_turns - current_turn_count - 1
+        return f"""
+
+CONVERSATION CONTINUATION: You can continue this discussion with the agent! ({remaining_turns} exchanges remaining)
+
+Feel free to ask clarifying questions or suggest areas for deeper exploration naturally within your response.
+If something needs clarification or you'd benefit from additional context, simply mention it conversationally.
+
+IMPORTANT: When you suggest follow-ups or ask questions, you MUST explicitly instruct the agent to use the continuation_id
+to respond. Use clear, direct language based on urgency:
+
+For optional follow-ups: "Please continue this conversation using the continuation_id from this response if you'd "
+"like to explore this further."
+
+For needed responses: "Please respond using the continuation_id from this response - your input is needed to proceed."
+
+For essential/critical responses: "RESPONSE REQUIRED: Please immediately continue using the continuation_id from "
+"this response. Cannot proceed without your clarification/input."
+
+This ensures the agent knows both HOW to maintain the conversation thread AND whether a response is optional, "
+"needed, or essential.
+
+The tool will automatically provide a continuation_id in the structured response that the agent can use in subsequent
+tool calls to maintain full conversation context across multiple exchanges.
+
+Remember: Only suggest follow-ups when they would genuinely add value to the discussion, and always instruct "
+"The agent to use the continuation_id when you do."""

--- a/utils/model_resolution.py
+++ b/utils/model_resolution.py
@@ -1,0 +1,89 @@
+"""
+Model resolution utilities for Zen MCP Server.
+
+This module provides shared model resolution logic used by both:
+1. MCP server mode (server.py)
+2. Skills standalone mode (zen_skill_runner.py)
+
+This ensures consistent behavior across both execution paths.
+"""
+
+import logging
+from typing import Optional
+
+from providers import ModelProviderRegistry
+from tools.models import ToolModelCategory
+
+logger = logging.getLogger(__name__)
+
+
+class ModelResolutionError(Exception):
+    """Raised when model resolution fails."""
+
+    def __init__(self, message: str, available_models: list[str], suggested_model: Optional[str] = None):
+        super().__init__(message)
+        self.available_models = available_models
+        self.suggested_model = suggested_model
+
+
+def resolve_model(
+    model_name: str,
+    tool_category: ToolModelCategory,
+    tool_name: str = "unknown",
+) -> str:
+    """
+    Resolve model name, handling 'auto' mode by selecting an appropriate model.
+
+    This function provides consistent model resolution across MCP and Skills modes.
+
+    Args:
+        model_name: The requested model name (may be 'auto')
+        tool_category: The tool's model category for fallback selection
+        tool_name: Name of the tool (for logging)
+
+    Returns:
+        Resolved model name (never 'auto')
+
+    Raises:
+        ModelResolutionError: If model cannot be resolved or is unavailable
+    """
+    # Handle auto mode - resolve to specific model
+    if model_name.lower() == "auto":
+        resolved_model = ModelProviderRegistry.get_preferred_fallback_model(tool_category)
+        if not resolved_model:
+            available_models = list(ModelProviderRegistry.get_available_models(respect_restrictions=True).keys())
+            raise ModelResolutionError(
+                f"Cannot resolve 'auto' model - no models available for category '{tool_category.value}'. "
+                f"Please configure API keys or specify a model explicitly.",
+                available_models=available_models,
+            )
+        logger.info(f"Auto mode resolved to {resolved_model} for {tool_name} (category: {tool_category.value})")
+        return resolved_model
+
+    # Validate explicit model is available
+    provider = ModelProviderRegistry.get_provider_for_model(model_name)
+    if not provider:
+        available_models = list(ModelProviderRegistry.get_available_models(respect_restrictions=True).keys())
+        suggested_model = ModelProviderRegistry.get_preferred_fallback_model(tool_category)
+        raise ModelResolutionError(
+            f"Model '{model_name}' is not available with current API keys. "
+            f"Available models: {', '.join(available_models)}. "
+            f"Suggested model for {tool_name}: '{suggested_model}' (category: {tool_category.value})",
+            available_models=available_models,
+            suggested_model=suggested_model,
+        )
+
+    return model_name
+
+
+def get_available_models_text() -> str:
+    """
+    Get a formatted string of available models.
+
+    Returns:
+        Comma-separated list of available model names, or a helpful message if none.
+    """
+    available_models = list(ModelProviderRegistry.get_available_models(respect_restrictions=True).keys())
+    if available_models:
+        return ", ".join(available_models)
+    return "No models detected. Configure provider credentials or set DEFAULT_MODEL to a valid option."

--- a/utils/storage_backend.py
+++ b/utils/storage_backend.py
@@ -1,35 +1,65 @@
 """
-In-memory storage backend for conversation threads
+Storage backends for conversation threads.
 
-This module provides a thread-safe, in-memory alternative to Redis for storing
-conversation contexts. It's designed for ephemeral MCP server sessions where
-conversations only need to persist during a single Claude session.
+This module provides multiple storage backends for conversation contexts:
+- InMemoryStorage: For MCP server mode (single persistent process)
+- SQLiteStorage: For Skills mode (cross-process persistence)
 
-⚠️  PROCESS-SPECIFIC STORAGE: This storage is confined to a single Python process.
-    Data stored in one process is NOT accessible from other processes or subprocesses.
-    This is why simulator tests that run server.py as separate subprocesses cannot
-    share conversation state between tool calls.
+The backend is selected via PAL_SKILL_STORAGE environment variable:
+- "memory" (default): Use in-memory storage (MCP mode)
+- "sqlite": Use SQLite for cross-process persistence (Skills mode)
 
-Key Features:
-- Thread-safe operations using locks
-- TTL support with automatic expiration
-- Background cleanup thread for memory management
-- Singleton pattern for consistent state within a single process
-- Drop-in replacement for Redis storage (for single-process scenarios)
+⚠️  PROCESS-SPECIFIC vs CROSS-PROCESS:
+    - InMemoryStorage: Data confined to single Python process
+    - SQLiteStorage: Data persists across process invocations
 """
 
 import logging
+import os
+import sqlite3
 import threading
 import time
-from typing import Optional
+from pathlib import Path
+from typing import Optional, Protocol, runtime_checkable
 
 from utils.env import get_env
 
 logger = logging.getLogger(__name__)
 
 
+# =============================================================================
+# Storage Protocol
+# =============================================================================
+
+
+@runtime_checkable
+class StorageBackend(Protocol):
+    """Protocol for storage backends."""
+
+    def get(self, key: str) -> Optional[str]:
+        """Retrieve value by key, returns None if not found or expired."""
+        ...
+
+    def setex(self, key: str, ttl_seconds: int, value: str) -> None:
+        """Store value with TTL (time-to-live) in seconds."""
+        ...
+
+    def set_with_ttl(self, key: str, ttl_seconds: int, value: str) -> None:
+        """Alias for setex, for compatibility."""
+        ...
+
+
+# =============================================================================
+# In-Memory Storage (for MCP mode)
+# =============================================================================
+
+
 class InMemoryStorage:
-    """Thread-safe in-memory storage for conversation threads"""
+    """Thread-safe in-memory storage for conversation threads.
+
+    Suitable for MCP server mode where the process persists.
+    Data is lost when the process exits.
+    """
 
     def __init__(self):
         self._store: dict[str, tuple[str, float]] = {}
@@ -98,17 +128,204 @@ class InMemoryStorage:
             self._cleanup_thread.join(timeout=1)
 
 
+# =============================================================================
+# SQLite Storage (for Skills mode - cross-process persistence)
+# =============================================================================
+
+
+class SQLiteStorage:
+    """SQLite-based storage for cross-process persistence.
+
+    Suitable for Skills mode where each invocation is a separate process.
+    Data persists in ~/.pal_mcp/sessions.db across process invocations.
+
+    Features:
+    - WAL mode for better concurrent access
+    - Automatic TTL expiration
+    - Thread-safe with RLock
+    """
+
+    def __init__(self, db_path: Optional[str] = None):
+        """Initialize SQLite storage.
+
+        Args:
+            db_path: Path to SQLite database. Defaults to ~/.pal_mcp/sessions.db
+        """
+        if db_path is None:
+            db_path = os.path.expanduser("~/.pal_mcp/sessions.db")
+
+        self.db_path = Path(db_path).expanduser().resolve()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self._lock = threading.RLock()
+
+        # Initialize database
+        self._init_db()
+
+        logger.info(f"SQLite storage initialized at {self.db_path}")
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Create a new connection for the current thread."""
+        conn = sqlite3.connect(
+            str(self.db_path),
+            check_same_thread=False,
+            timeout=10.0,
+            isolation_level=None,  # autocommit mode
+        )
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
+        conn.execute("PRAGMA busy_timeout=10000;")
+        return conn
+
+    def _init_db(self) -> None:
+        """Initialize database schema."""
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS sessions (
+                        key TEXT PRIMARY KEY,
+                        value TEXT NOT NULL,
+                        expire_at REAL
+                    );
+                    """
+                )
+                # Create index for expiration queries
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_expire_at ON sessions(expire_at);
+                    """
+                )
+            finally:
+                conn.close()
+
+    def setex(self, key: str, ttl_seconds: int, value: str) -> None:
+        """Store value with TTL."""
+        expire_at = time.time() + ttl_seconds
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO sessions (key, value, expire_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(key) DO UPDATE SET
+                        value = excluded.value,
+                        expire_at = excluded.expire_at;
+                    """,
+                    (key, value, expire_at),
+                )
+                logger.debug(f"SQLite: Stored key {key} with TTL {ttl_seconds}s")
+
+                # Probabilistic cleanup (2% chance)
+                self._maybe_cleanup(conn)
+            finally:
+                conn.close()
+
+    def set_with_ttl(self, key: str, ttl_seconds: int, value: str) -> None:
+        """Alias for setex."""
+        self.setex(key, ttl_seconds, value)
+
+    def get(self, key: str) -> Optional[str]:
+        """Retrieve value if not expired."""
+        now = time.time()
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                cursor = conn.execute(
+                    "SELECT value, expire_at FROM sessions WHERE key = ?;",
+                    (key,),
+                )
+                row = cursor.fetchone()
+
+                if not row:
+                    logger.debug(f"SQLite: Key {key} not found")
+                    return None
+
+                value, expire_at = row
+
+                if expire_at is not None and expire_at <= now:
+                    # Expired, delete it
+                    conn.execute("DELETE FROM sessions WHERE key = ?;", (key,))
+                    logger.debug(f"SQLite: Key {key} expired and removed")
+                    return None
+
+                logger.debug(f"SQLite: Retrieved key {key}")
+                return value
+            finally:
+                conn.close()
+
+    def _maybe_cleanup(self, conn: sqlite3.Connection, probability: float = 0.02) -> None:
+        """Probabilistic cleanup of expired entries.
+
+        Only runs with given probability to avoid overhead on every write.
+        """
+        if os.urandom(1)[0] / 255.0 <= probability:
+            deleted = conn.execute(
+                "DELETE FROM sessions WHERE expire_at IS NOT NULL AND expire_at <= ?;",
+                (time.time(),),
+            ).rowcount
+            if deleted:
+                logger.debug(f"SQLite: Cleaned up {deleted} expired sessions")
+
+    def cleanup_expired(self) -> int:
+        """Force cleanup of all expired entries. Returns count of deleted entries."""
+        with self._lock:
+            conn = self._get_connection()
+            try:
+                deleted = conn.execute(
+                    "DELETE FROM sessions WHERE expire_at IS NOT NULL AND expire_at <= ?;",
+                    (time.time(),),
+                ).rowcount
+                if deleted:
+                    logger.info(f"SQLite: Cleaned up {deleted} expired sessions")
+                return deleted
+            finally:
+                conn.close()
+
+
+# =============================================================================
+# Storage Backend Factory
+# =============================================================================
+
 # Global singleton instance
-_storage_instance = None
+_storage_instance: Optional[StorageBackend] = None
 _storage_lock = threading.Lock()
 
 
-def get_storage_backend() -> InMemoryStorage:
-    """Get the global storage instance (singleton pattern)"""
+def get_storage_backend() -> StorageBackend:
+    """Get the global storage instance (singleton pattern).
+
+    The backend is selected via PAL_SKILL_STORAGE environment variable:
+    - "memory" (default): InMemoryStorage for MCP mode
+    - "sqlite": SQLiteStorage for Skills mode (cross-process persistence)
+
+    For Skills mode, set PAL_SKILL_STORAGE=sqlite before importing this module.
+    """
     global _storage_instance
-    if _storage_instance is None:
-        with _storage_lock:
-            if _storage_instance is None:
+
+    if _storage_instance is not None:
+        return _storage_instance
+
+    with _storage_lock:
+        if _storage_instance is not None:
+            return _storage_instance
+
+        storage_type = os.environ.get("PAL_SKILL_STORAGE", "memory").lower()
+
+        if storage_type == "sqlite":
+            # SQLite storage for Skills mode
+            db_path = os.environ.get("PAL_SKILL_STORAGE_PATH")
+            try:
+                _storage_instance = SQLiteStorage(db_path)
+                logger.info("Using SQLite storage for cross-process persistence")
+            except Exception as e:
+                logger.warning(f"Failed to initialize SQLite storage: {e}, falling back to memory")
                 _storage_instance = InMemoryStorage()
-                logger.info("Initialized in-memory conversation storage")
-    return _storage_instance
+        else:
+            # Default: in-memory storage for MCP mode
+            _storage_instance = InMemoryStorage()
+            logger.info("Using in-memory storage (MCP mode)")
+
+        return _storage_instance

--- a/utils/tool_entry.py
+++ b/utils/tool_entry.py
@@ -1,0 +1,378 @@
+"""
+Shared tool entry point logic for MCP server and Skills mode.
+
+This module provides unified pre-execution processing that ensures consistent
+behavior between MCP server mode and Skills standalone mode.
+
+DESIGN PRINCIPLE:
+- MCP server mode imports and uses parse_model_option from this module
+- Skills mode calls prepare_tool_arguments which uses the same functions
+- Both modes share the same underlying utilities (model resolution, file validation, etc.)
+
+This ensures that:
+1. Tools behave identically regardless of invocation method
+2. continuation_id works across both modes (via SQLite storage in Skills mode)
+3. Model options (model:for, model:against) are parsed consistently
+4. File size validation is applied uniformly
+5. ModelContext is created and passed to tools
+
+SINGLE SOURCE OF TRUTH:
+- parse_model_option: Defined here, imported by server.py
+- prepare_tool_arguments: Used by Skills mode
+- reconstruct_thread_context_for_skills: Skills version of context reconstruction
+"""
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def parse_model_option(model_string: str) -> tuple[str, Optional[str]]:
+    """
+    Parse model:option format into model name and option.
+
+    SINGLE SOURCE OF TRUTH: This function is the canonical implementation.
+    server.py imports and uses this function directly.
+
+    Handles different formats:
+    - OpenRouter models: preserve :free, :beta, :preview suffixes as part of model name
+    - Ollama/Custom models: split on : to extract tags like :latest
+    - Consensus stance: extract options like :for, :against
+
+    Args:
+        model_string: String that may contain "model:option" format
+
+    Returns:
+        tuple: (model_name, option) where option may be None
+    """
+    if ":" in model_string and not model_string.startswith("http"):  # Avoid parsing URLs
+        # Check if this looks like an OpenRouter model (contains /)
+        if "/" in model_string and model_string.count(":") == 1:
+            # Could be openai/gpt-4:something - check what comes after colon
+            parts = model_string.split(":", 1)
+            suffix = parts[1].strip().lower()
+
+            # Known OpenRouter suffixes to preserve
+            if suffix in ["free", "beta", "preview"]:
+                return model_string.strip(), None
+
+        # For other patterns (Ollama tags, consensus stances), split normally
+        parts = model_string.split(":", 1)
+        model_name = parts[0].strip()
+        model_option = parts[1].strip() if len(parts) > 1 else None
+        return model_name, model_option
+    return model_string.strip(), None
+
+
+async def prepare_tool_arguments(
+    tool,
+    arguments: dict[str, Any],
+    tool_name: str,
+    *,
+    skip_continuation: bool = False,
+) -> dict[str, Any]:
+    """
+    Prepare tool arguments with full pre-execution processing.
+
+    This function replicates the logic from server.py handle_call_tool(),
+    providing the same processing for Skills mode:
+
+    1. continuation_id handling (thread context reconstruction)
+    2. model:option parsing
+    3. Model resolution (handles 'auto' mode)
+    4. ModelContext creation
+    5. File size validation
+
+    Args:
+        tool: The tool instance
+        arguments: Raw input arguments from CLI/caller
+        tool_name: Name of the tool being executed
+        skip_continuation: If True, skip continuation_id processing (for testing)
+
+    Returns:
+        Enhanced arguments dict with:
+        - _model_context: ModelContext instance
+        - _resolved_model_name: Resolved model name
+        - model: Updated with resolved model
+        - (if continuation_id): Enhanced prompt with conversation history
+
+    Raises:
+        ValueError: For invalid continuation_id or unavailable models
+        ToolExecutionError-like dict: For file size validation failures
+    """
+    from config import DEFAULT_MODEL
+    from utils.model_resolution import ModelResolutionError, resolve_model
+
+    enhanced_args = arguments.copy()
+
+    # =========================================================================
+    # 1. Handle continuation_id (thread context reconstruction)
+    # =========================================================================
+    if not skip_continuation and "continuation_id" in enhanced_args and enhanced_args["continuation_id"]:
+        continuation_id = enhanced_args["continuation_id"]
+        logger.debug(f"[SKILLS] Resuming conversation thread: {continuation_id}")
+        enhanced_args = await reconstruct_thread_context_for_skills(enhanced_args, tool)
+
+    # =========================================================================
+    # 2. Parse model:option format
+    # =========================================================================
+    model_name = enhanced_args.get("model") or DEFAULT_MODEL
+    model_name, model_option = parse_model_option(model_name)
+    if model_option:
+        logger.debug(f"[SKILLS] Parsed model format - model: '{model_name}', option: '{model_option}'")
+
+    # =========================================================================
+    # 3. Skip model resolution for tools that don't require models
+    # =========================================================================
+    if not tool.requires_model():
+        logger.debug(f"[SKILLS] Tool {tool_name} doesn't require model - skipping model processing")
+        return enhanced_args
+
+    # =========================================================================
+    # 4. Resolve model (handles 'auto' mode)
+    # =========================================================================
+    tool_category = tool.get_model_category()
+
+    try:
+        resolved_model = resolve_model(model_name, tool_category, tool_name=tool_name)
+        enhanced_args["model"] = resolved_model
+        logger.debug(f"[SKILLS] Resolved model: {resolved_model}")
+    except ModelResolutionError:
+        # Re-raise with context for caller to handle
+        raise
+
+    # =========================================================================
+    # 5. Create ModelContext
+    # =========================================================================
+    from utils.model_context import ModelContext
+
+    model_context = ModelContext(resolved_model, model_option)
+    enhanced_args["_model_context"] = model_context
+    enhanced_args["_resolved_model_name"] = resolved_model
+    logger.debug(
+        f"[SKILLS] ModelContext created for {resolved_model} "
+        f"with {model_context.capabilities.context_window} token capacity"
+    )
+    if model_option:
+        logger.debug(f"[SKILLS] Model option stored: '{model_option}'")
+
+    # =========================================================================
+    # 6. File size validation
+    # =========================================================================
+    from utils.file_utils import check_total_file_size
+
+    argument_files = enhanced_args.get("absolute_file_paths")
+    if argument_files:
+        logger.debug(f"[SKILLS] Checking file sizes for {len(argument_files)} files")
+        file_size_check = check_total_file_size(argument_files, resolved_model)
+        if file_size_check:
+            logger.warning(f"[SKILLS] File size check failed for {tool_name}")
+            # Return error dict that caller should handle
+            raise FileSizeExceededError(file_size_check)
+
+    return enhanced_args
+
+
+class FileSizeExceededError(Exception):
+    """Raised when file sizes exceed the model's token limit."""
+
+    def __init__(self, error_response: dict):
+        self.error_response = error_response
+        super().__init__(error_response.get("content", "File size exceeded"))
+
+
+def _get_fallback_model(tool) -> Optional[str]:
+    """
+    Get a fallback model when the requested model is unavailable.
+
+    This logic is shared between MCP server and Skills mode to ensure
+    consistent fallback behavior.
+
+    Args:
+        tool: The tool instance (for model category resolution)
+
+    Returns:
+        Fallback model name, or None if no models are available
+    """
+    from providers.registry import ModelProviderRegistry
+
+    fallback_model = None
+
+    # First try to get a preferred fallback for the tool's category
+    if tool is not None:
+        try:
+            fallback_model = ModelProviderRegistry.get_preferred_fallback_model(tool.get_model_category())
+        except Exception:
+            pass
+
+    # If no category-specific fallback, use any available model
+    if fallback_model is None:
+        available_models = ModelProviderRegistry.get_available_model_names()
+        if available_models:
+            fallback_model = available_models[0]
+
+    return fallback_model
+
+
+async def reconstruct_thread_context_for_skills(
+    arguments: dict[str, Any],
+    tool,
+) -> dict[str, Any]:
+    """
+    Reconstruct conversation context for Skills mode.
+
+    This mirrors the reconstruct_thread_context function from server.py,
+    adapted for Skills mode which uses SQLite storage for cross-process persistence.
+
+    Args:
+        arguments: Original arguments with continuation_id
+        tool: The tool instance (for model category resolution)
+
+    Returns:
+        Enhanced arguments with conversation history embedded
+    """
+    from utils.conversation_memory import add_turn, build_conversation_history, get_thread
+    from utils.follow_up import get_follow_up_instructions
+    from utils.model_context import ModelContext
+
+    continuation_id = arguments["continuation_id"]
+
+    # Get thread context from storage (SQLite in Skills mode)
+    logger.debug(f"[SKILLS] Looking up thread {continuation_id} in storage")
+    context = get_thread(continuation_id)
+
+    if not context:
+        logger.warning(f"[SKILLS] Thread not found: {continuation_id}")
+        raise ValueError(
+            f"Conversation thread '{continuation_id}' was not found or has expired. "
+            f"This may happen if the conversation was created more than 3 hours ago. "
+            f"Please restart the conversation by providing your full question/prompt without the "
+            f"continuation_id parameter."
+        )
+
+    # Add user's new input to the conversation
+    user_prompt = arguments.get("prompt", "")
+    if user_prompt:
+        user_files = arguments.get("absolute_file_paths") or []
+        logger.debug(f"[SKILLS] Adding user turn to thread {continuation_id}")
+        success = add_turn(continuation_id, "user", user_prompt, files=user_files)
+        if not success:
+            logger.warning(f"[SKILLS] Failed to add user turn to thread {continuation_id}")
+
+    # Determine if tool requires a model
+    requires_model = tool.requires_model() if tool else True
+
+    # Check if we should use the model from the previous conversation turn
+    model_from_args = arguments.get("model")
+    if requires_model and not model_from_args and context.turns:
+        for turn in reversed(context.turns):
+            if turn.role == "assistant" and turn.model_name:
+                arguments["model"] = turn.model_name
+                logger.debug(f"[SKILLS] Using model from previous turn: {turn.model_name}")
+                break
+
+    # Create model context for history building
+    model_context = arguments.get("_model_context")
+
+    if requires_model and model_context is None:
+        try:
+            model_context = ModelContext.from_arguments(arguments)
+            arguments.setdefault("_resolved_model_name", model_context.model_name)
+        except ValueError:
+            # Fallback to any available model
+            from providers.registry import ModelProviderRegistry
+
+            fallback_model = _get_fallback_model(tool)
+
+            if fallback_model is None:
+                raise ValueError("No available models for conversation continuation")
+
+            logger.debug(f"[SKILLS] Using fallback model '{fallback_model}' for context reconstruction")
+            model_context = ModelContext(fallback_model)
+            arguments["_model_context"] = model_context
+            arguments["_resolved_model_name"] = fallback_model
+
+    # Verify provider availability for the model (same as MCP server mode)
+    # This ensures we don't fail later when trying to use an unavailable model
+    if requires_model and model_context:
+        from providers.registry import ModelProviderRegistry
+
+        provider = ModelProviderRegistry.get_provider_for_model(model_context.model_name)
+        if provider is None:
+            # Model is not available, try to find a fallback
+            fallback_model = _get_fallback_model(tool)
+
+            if fallback_model is None:
+                raise ValueError(
+                    f"Conversation continuation failed: model '{model_context.model_name}' "
+                    f"is not available with current API keys."
+                )
+
+            logger.debug(
+                f"[SKILLS] Model '{model_context.model_name}' unavailable; "
+                f"swapping to '{fallback_model}' for context reconstruction"
+            )
+            model_context = ModelContext(fallback_model)
+            arguments["_model_context"] = model_context
+            arguments["_resolved_model_name"] = fallback_model
+    elif not requires_model and model_context is None:
+        # Tool doesn't require model but we need one for context reconstruction
+        from providers.registry import ModelProviderRegistry
+
+        fallback_model = _get_fallback_model(tool)
+
+        if fallback_model is None:
+            raise ValueError(
+                "Conversation continuation failed: no available models detected for context reconstruction."
+            )
+
+        logger.debug(
+            f"[SKILLS] Using fallback model '{fallback_model}' for context reconstruction "
+            f"of tool without model requirement"
+        )
+        model_context = ModelContext(fallback_model)
+        arguments["_model_context"] = model_context
+        arguments["_resolved_model_name"] = fallback_model
+
+    # Build conversation history with model-specific limits
+    logger.debug(f"[SKILLS] Building conversation history for thread {continuation_id}")
+    conversation_history, conversation_tokens = build_conversation_history(context, model_context)
+    logger.debug(f"[SKILLS] Conversation history built: {conversation_tokens:,} tokens")
+
+    # Add follow-up instructions
+    follow_up_instructions = get_follow_up_instructions(len(context.turns))
+
+    # Merge conversation history with current prompt
+    original_prompt = arguments.get("prompt", "")
+
+    if conversation_history:
+        enhanced_prompt = (
+            f"{conversation_history}\n\n=== NEW USER INPUT ===\n{original_prompt}\n\n{follow_up_instructions}"
+        )
+    else:
+        enhanced_prompt = f"{original_prompt}\n\n{follow_up_instructions}"
+
+    # Build enhanced arguments
+    enhanced_arguments = arguments.copy()
+    enhanced_arguments["prompt"] = enhanced_prompt
+    enhanced_arguments["_original_user_prompt"] = original_prompt
+
+    # Calculate remaining token budget
+    if model_context:
+        token_allocation = model_context.calculate_token_allocation()
+        remaining_tokens = token_allocation.content_tokens - conversation_tokens
+        enhanced_arguments["_remaining_tokens"] = max(0, remaining_tokens)
+        enhanced_arguments["_model_context"] = model_context
+
+        logger.debug(f"[SKILLS] Token budget - remaining: {remaining_tokens:,}")
+
+    # Merge initial context parameters
+    if context.initial_context:
+        for key, value in context.initial_context.items():
+            if key not in enhanced_arguments and key not in ["temperature", "thinking_mode", "model"]:
+                enhanced_arguments[key] = value
+
+    logger.info(f"[SKILLS] Reconstructed context for thread {continuation_id} (turn {len(context.turns)})")
+
+    return enhanced_arguments


### PR DESCRIPTION
## Description

Adds Claude Code Agent Skills support, enabling PAL tools to run as standalone executable scripts outside of MCP server mode. This is an **exploratory implementation** - feedback and suggestions are welcome!

## Changes Made

- [x] Added `scripts/pal_skill_runner.py` - Main skill execution runner with tool registry
- [x] Added `install-skills.sh` - Installation script for deploying skills to `~/.claude/skills/`
- [x] Added `skills/pal-*/` - 17 bundled skill directories (chat, thinkdeep, analyze, etc.)
- [x] Added `skills-optional/pal-*/` - 6 optional skill directories
- [x] Updated `utils/storage_backend.py` - Add `PAL_SKILL_STORAGE` environment variable support
- [x] Updated `utils/conversation_memory.py` - Documentation updates for Skills mode
- [x] Updated `tests/conftest.py` - Reset ModelRestrictionService singleton for test isolation
- [x] Updated `tests/test_mcp_error_handling.py` - MCP SDK 1.9.0 compatibility fix
- [ ] Breaking changes introduced (N/A)
- [ ] Dependencies added/removed (N/A)

## Testing

- [x] All linting passes (ruff, black, isort)
- [x] All unit tests pass (`851 passed, 4 skipped`)
- [x] Skills can be executed standalone via `run.sh`
- [x] Installation script correctly deploys skills
- [x] Path detection works in both development and installed modes
- [ ] Simulator tests pass (N/A - no core tool changes)

## Related Issues

Closes #346

## Checklist

- [x] PR title follows Conventional Commits
- [x] Activated venv and ran `./code_quality_checks.sh`
- [x] Self-review completed
- [x] Tests added/updated for all changes
- [x] Documentation updated where needed
- [x] All unit tests passing
- [x] Ready for review

## Additional Notes

**What are Claude Code Agent Skills?**

Skills are standalone executable scripts that can be invoked directly by Claude Code without requiring the full MCP server. Each skill:
- Has its own `run.sh` entry point
- Contains a `SKILL.md` documentation file  
- Can be installed independently to user's skills directory

**Installation:**
```bash
# Install all skills to ~/.claude/skills/
./install-skills.sh

# Or install specific skills
./install-skills.sh pal-chat pal-thinkdeep
```

**Discussion Welcome:**

This is an initial exploration of Skills mode support. As discussed in #346, Skills mode could help reduce token overhead compared to MCP mode. If you have better ideas or suggestions, please comment!