### PR TITLE
fix: add Gemini-compliant JSON Schema items definitions

### DIFF
--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -224,7 +224,29 @@ class AnalyzeTool(WorkflowTool):
             },
             "issues_found": {
                 "type": "array",
-                "items": {"type": "object"},
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "severity": {
+                            "type": "string",
+                            "enum": ["critical", "high", "medium", "low"],
+                            "description": "Severity level of the issue",
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Description of the issue found",
+                        },
+                        "location": {
+                            "type": "string",
+                            "description": "File path or code location where the issue was found",
+                        },
+                        "suggestion": {
+                            "type": "string",
+                            "description": "Suggested fix or remediation",
+                        },
+                    },
+                    "required": ["severity", "description"],
+                },
                 "description": "Issues or concerns identified during analysis, each with severity level (critical, high, medium, low)",
             },
             "analysis_type": {

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -222,33 +222,6 @@ class AnalyzeTool(WorkflowTool):
                 "items": {"type": "string"},
                 "description": ANALYZE_WORKFLOW_FIELD_DESCRIPTIONS["images"],
             },
-            "issues_found": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "severity": {
-                            "type": "string",
-                            "enum": ["critical", "high", "medium", "low"],
-                            "description": "Severity level of the issue",
-                        },
-                        "description": {
-                            "type": "string",
-                            "description": "Description of the issue found",
-                        },
-                        "location": {
-                            "type": "string",
-                            "description": "File path or code location where the issue was found",
-                        },
-                        "suggestion": {
-                            "type": "string",
-                            "description": "Suggested fix or remediation",
-                        },
-                    },
-                    "required": ["severity", "description"],
-                },
-                "description": "Issues or concerns identified during analysis, each with severity level (critical, high, medium, low)",
-            },
             "analysis_type": {
                 "type": "string",
                 "enum": ["architecture", "performance", "security", "quality", "general"],

--- a/tools/codereview.py
+++ b/tools/codereview.py
@@ -202,7 +202,29 @@ class CodeReviewTool(WorkflowTool):
             },
             "issues_found": {
                 "type": "array",
-                "items": {"type": "object"},
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "severity": {
+                            "type": "string",
+                            "enum": ["critical", "high", "medium", "low"],
+                            "description": "Severity level of the issue",
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Description of the issue found",
+                        },
+                        "location": {
+                            "type": "string",
+                            "description": "File path or code location where the issue was found",
+                        },
+                        "suggestion": {
+                            "type": "string",
+                            "description": "Suggested fix or remediation",
+                        },
+                    },
+                    "required": ["severity", "description"],
+                },
                 "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
             },
             "images": {

--- a/tools/codereview.py
+++ b/tools/codereview.py
@@ -200,33 +200,6 @@ class CodeReviewTool(WorkflowTool):
                 "default": "external",
                 "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS.get("review_validation_type", ""),
             },
-            "issues_found": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "severity": {
-                            "type": "string",
-                            "enum": ["critical", "high", "medium", "low"],
-                            "description": "Severity level of the issue",
-                        },
-                        "description": {
-                            "type": "string",
-                            "description": "Description of the issue found",
-                        },
-                        "location": {
-                            "type": "string",
-                            "description": "File path or code location where the issue was found",
-                        },
-                        "suggestion": {
-                            "type": "string",
-                            "description": "Suggested fix or remediation",
-                        },
-                    },
-                    "required": ["severity", "description"],
-                },
-                "description": CODEREVIEW_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
-            },
             "images": {
                 "type": "array",
                 "items": {"type": "string"},

--- a/tools/consensus.py
+++ b/tools/consensus.py
@@ -247,7 +247,29 @@ of the evidence, even when it strongly points in one direction.""",
             },
             "model_responses": {
                 "type": "array",
-                "items": {"type": "object"},
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "model": {
+                            "type": "string",
+                            "description": "Model name that provided this response",
+                        },
+                        "stance": {
+                            "type": "string",
+                            "enum": ["for", "against", "neutral"],
+                            "description": "The stance this model was given",
+                        },
+                        "response": {
+                            "type": "string",
+                            "description": "The model's response content",
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "description": "When the response was received",
+                        },
+                    },
+                    "required": ["model", "response"],
+                },
                 "description": CONSENSUS_WORKFLOW_FIELD_DESCRIPTIONS["model_responses"],
             },
             "images": {

--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -203,7 +203,29 @@ class PrecommitTool(WorkflowTool):
             },
             "issues_found": {
                 "type": "array",
-                "items": {"type": "object"},
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "severity": {
+                            "type": "string",
+                            "enum": ["critical", "high", "medium", "low"],
+                            "description": "Severity level of the issue",
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Description of the issue found",
+                        },
+                        "location": {
+                            "type": "string",
+                            "description": "File path or code location where the issue was found",
+                        },
+                        "suggestion": {
+                            "type": "string",
+                            "description": "Suggested fix or remediation",
+                        },
+                    },
+                    "required": ["severity", "description"],
+                },
                 "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
             },
             "images": {

--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -201,33 +201,6 @@ class PrecommitTool(WorkflowTool):
                 "default": "external",
                 "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["precommit_type"],
             },
-            "issues_found": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "severity": {
-                            "type": "string",
-                            "enum": ["critical", "high", "medium", "low"],
-                            "description": "Severity level of the issue",
-                        },
-                        "description": {
-                            "type": "string",
-                            "description": "Description of the issue found",
-                        },
-                        "location": {
-                            "type": "string",
-                            "description": "File path or code location where the issue was found",
-                        },
-                        "suggestion": {
-                            "type": "string",
-                            "description": "Suggested fix or remediation",
-                        },
-                    },
-                    "required": ["severity", "description"],
-                },
-                "description": PRECOMMIT_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
-            },
             "images": {
                 "type": "array",
                 "items": {"type": "string"},

--- a/tools/refactor.py
+++ b/tools/refactor.py
@@ -226,7 +226,30 @@ class RefactorTool(WorkflowTool):
             },
             "issues_found": {
                 "type": "array",
-                "items": {"type": "object"},
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "severity": {
+                            "type": "string",
+                            "enum": ["critical", "high", "medium", "low"],
+                            "description": "Severity level of the issue",
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": ["codesmells", "decompose", "modernize", "organization"],
+                            "description": "Type of refactoring opportunity",
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Description of the refactoring opportunity",
+                        },
+                        "location": {
+                            "type": "string",
+                            "description": "File path or code location",
+                        },
+                    },
+                    "required": ["severity", "description"],
+                },
                 "description": REFACTOR_FIELD_DESCRIPTIONS["issues_found"],
             },
             "images": {

--- a/tools/secaudit.py
+++ b/tools/secaudit.py
@@ -392,33 +392,6 @@ class SecauditTool(WorkflowTool):
                 "enum": ["exploring", "low", "medium", "high", "very_high", "almost_certain", "certain"],
                 "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["confidence"],
             },
-            "issues_found": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "severity": {
-                            "type": "string",
-                            "enum": ["critical", "high", "medium", "low"],
-                            "description": "Severity level of the issue",
-                        },
-                        "description": {
-                            "type": "string",
-                            "description": "Description of the issue found",
-                        },
-                        "location": {
-                            "type": "string",
-                            "description": "File path or code location where the issue was found",
-                        },
-                        "suggestion": {
-                            "type": "string",
-                            "description": "Suggested fix or remediation",
-                        },
-                    },
-                    "required": ["severity", "description"],
-                },
-                "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
-            },
             "images": {
                 "type": "array",
                 "items": {"type": "string"},

--- a/tools/secaudit.py
+++ b/tools/secaudit.py
@@ -394,7 +394,29 @@ class SecauditTool(WorkflowTool):
             },
             "issues_found": {
                 "type": "array",
-                "items": {"type": "object"},
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "severity": {
+                            "type": "string",
+                            "enum": ["critical", "high", "medium", "low"],
+                            "description": "Severity level of the issue",
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Description of the issue found",
+                        },
+                        "location": {
+                            "type": "string",
+                            "description": "File path or code location where the issue was found",
+                        },
+                        "suggestion": {
+                            "type": "string",
+                            "description": "Suggested fix or remediation",
+                        },
+                    },
+                    "required": ["severity", "description"],
+                },
                 "description": SECAUDIT_WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
             },
             "images": {

--- a/tools/workflow/schema_builders.py
+++ b/tools/workflow/schema_builders.py
@@ -60,7 +60,29 @@ class WorkflowSchemaBuilder:
         },
         "issues_found": {
             "type": "array",
-            "items": {"type": "object"},
+            "items": {
+                "type": "object",
+                "properties": {
+                    "severity": {
+                        "type": "string",
+                        "enum": ["critical", "high", "medium", "low"],
+                        "description": "Severity level of the issue",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the issue found",
+                    },
+                    "location": {
+                        "type": "string",
+                        "description": "File path or code location where the issue was found",
+                    },
+                    "suggestion": {
+                        "type": "string",
+                        "description": "Suggested fix or remediation",
+                    },
+                },
+                "required": ["severity", "description"],
+            },
             "description": WORKFLOW_FIELD_DESCRIPTIONS["issues_found"],
         },
         "confidence": {


### PR DESCRIPTION
## Summary

Fixes #358 - Gemini API rejects PAL MCP tools due to incomplete JSON Schema definitions.

- Added proper `properties` definitions to all `items: {"type": "object"}` schemas
- Fixed 7 tool files with underspecified array item schemas
- Refactored to remove duplicate `issues_found` schema definitions

## Changes

| File | Parameter Fixed |
|------|-----------------|
| `tools/workflow/schema_builders.py` | `issues_found` (shared) |
| `tools/analyze.py` | `issues_found` |
| `tools/consensus.py` | `model_responses` |
| `tools/secaudit.py` | `issues_found` |
| `tools/refactor.py` | `issues_found` |
| `tools/codereview.py` | `issues_found` |
| `tools/precommit.py` | `issues_found` |

## Test plan

- [x] All unit tests pass
- [x] Manual test with Gemini model