### PR TITLE
feat(models): add Grok 4 Fast model variants + test coverage expanded

### DIFF
--- a/conf/xai_models.json
+++ b/conf/xai_models.json
@@ -20,7 +20,8 @@
       "use_openai_response_api": "Set to true when the model must use the /responses endpoint (reasoning models like GPT-5.2 Pro). Leave false/omit for standard chat completions.",
       "default_reasoning_effort": "Default reasoning effort level for models that support it (e.g., 'low', 'medium', 'high'). Omit if not applicable.",
       "description": "Human-readable description of the model",
-      "intelligence_score": "1-20 human rating used as the primary signal for auto-mode model ordering"
+      "intelligence_score": "1-20 human rating used as the primary signal for auto-mode model ordering",
+      "allow_code_generation": "Whether the model is optimized for code generation workflows (specialized coding models)"
     }
   },
   "models": [
@@ -28,9 +29,7 @@
       "model_name": "grok-4",
       "friendly_name": "X.AI (Grok 4)",
       "aliases": [
-        "grok",
-        "grok4",
-        "grok-4"
+        "grok4"
       ],
       "intelligence_score": 16,
       "description": "GROK-4 (256K context) - Frontier multimodal reasoning model with advanced capabilities",
@@ -49,14 +48,16 @@
       "model_name": "grok-4-1-fast-reasoning",
       "friendly_name": "X.AI (Grok 4.1 Fast Reasoning)",
       "aliases": [
+        "grok",
         "grok-4.1",
         "grok-4-1",
         "grok-4.1-fast-reasoning",
         "grok-4.1-fast-reasoning-latest",
-        "grok-4.1-fast"
+        "grok-4.1-fast",
+        "grok-4-1-fast"
       ],
       "intelligence_score": 15,
-      "description": "GROK-4.1 Fast Reasoning (2M context) - High-performance multimodal reasoning model with function calling",
+      "description": "GROK-4.1 Fast Reasoning (2M context) - Cost-efficient frontier multimodal model optimized for high-performance agentic tool calling with exceptional token efficiency. Default 'grok' alias for cost savings.",
       "context_window": 2000000,
       "max_output_tokens": 2000000,
       "supports_extended_thinking": true,
@@ -67,6 +68,85 @@
       "supports_images": true,
       "supports_temperature": true,
       "max_image_size_mb": 20.0
+    },
+    {
+      "model_name": "grok-4-1-fast-non-reasoning",
+      "friendly_name": "X.AI (Grok 4.1 Fast Non-Reasoning)",
+      "aliases": [
+        "grok-4.1-fast-non-reasoning",
+        "grok-4-1-fast-non-reasoning-latest"
+      ],
+      "intelligence_score": 13,
+      "description": "GROK-4.1 Fast Non-Reasoning (2M context) - Ultra-fast text-to-text generation optimized for speed and stability without advanced reasoning",
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": false,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true
+    },
+    {
+      "model_name": "grok-4-fast",
+      "friendly_name": "X.AI (Grok 4 Fast Reasoning)",
+      "aliases": [
+        "grok-4-fast-reasoning",
+        "grok-4-fast-reasoning-latest",
+        "grok4fast"
+      ],
+      "intelligence_score": 15,
+      "description": "GROK-4 Fast Reasoning (2M context) - Cost-efficient frontier reasoning model with 98% lower cost vs Grok 4 while achieving comparable benchmark performance",
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": true,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": true,
+      "supports_temperature": true,
+      "max_image_size_mb": 20.0
+    },
+    {
+      "model_name": "grok-4-fast-non-reasoning",
+      "friendly_name": "X.AI (Grok 4 Fast Non-Reasoning)",
+      "aliases": [
+        "grok-4-fast-non-reasoning-latest"
+      ],
+      "intelligence_score": 13,
+      "description": "GROK-4 Fast Non-Reasoning (2M context) - Ultra-fast text generation optimized for low latency without reasoning overhead",
+      "context_window": 2000000,
+      "max_output_tokens": 2000000,
+      "supports_extended_thinking": false,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true
+    },
+    {
+      "model_name": "grok-code-fast-1",
+      "friendly_name": "X.AI (Grok Code Fast 1)",
+      "aliases": [
+        "grok-code-fast",
+        "grok-code-fast-1-0825",
+        "grokcodefast"
+      ],
+      "intelligence_score": 14,
+      "description": "GROK Code Fast 1 (256K context) - Speedy and economical reasoning model specialized for agentic coding workflows",
+      "context_window": 256000,
+      "max_output_tokens": 256000,
+      "supports_extended_thinking": true,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true,
+      "allow_code_generation": true
     }
   ]
 }

--- a/tests/test_auto_mode_provider_selection.py
+++ b/tests/test_auto_mode_provider_selection.py
@@ -320,7 +320,7 @@ class TestAutoModeProviderSelection:
                 ("pro", ProviderType.GOOGLE, "gemini-3-pro-preview"),  # "pro" now resolves to gemini-3-pro-preview
                 ("mini", ProviderType.OPENAI, "gpt-5-mini"),  # "mini" now resolves to gpt-5-mini
                 ("o3mini", ProviderType.OPENAI, "o3-mini"),
-                ("grok", ProviderType.XAI, "grok-4"),
+                ("grok", ProviderType.XAI, "grok-4-1-fast-reasoning"),  # 'grok' now defaults to cost-efficient model
                 ("grok-4.1-fast-reasoning", ProviderType.XAI, "grok-4-1-fast-reasoning"),
             ]
 

--- a/tests/test_supported_models_aliases.py
+++ b/tests/test_supported_models_aliases.py
@@ -84,18 +84,19 @@ class TestSupportedModelsAliases:
             assert isinstance(config.aliases, list), f"{model_name} aliases must be a list"
 
         # Test specific aliases
-        assert "grok" in provider.MODEL_CAPABILITIES["grok-4"].aliases
+        # 'grok' now defaults to cost-efficient grok-4-1-fast-reasoning
+        assert "grok" in provider.MODEL_CAPABILITIES["grok-4-1-fast-reasoning"].aliases
         assert "grok4" in provider.MODEL_CAPABILITIES["grok-4"].aliases
         assert "grok-4.1-fast-reasoning" in provider.MODEL_CAPABILITIES["grok-4-1-fast-reasoning"].aliases
 
         # Test alias resolution
-        assert provider._resolve_model_name("grok") == "grok-4"
+        assert provider._resolve_model_name("grok") == "grok-4-1-fast-reasoning"  # cost-efficient default
         assert provider._resolve_model_name("grok4") == "grok-4"
         assert provider._resolve_model_name("grok-4.1-fast-reasoning") == "grok-4-1-fast-reasoning"
         assert provider._resolve_model_name("grok-4.1-fast-reasoning-latest") == "grok-4-1-fast-reasoning"
 
         # Test case insensitive resolution
-        assert provider._resolve_model_name("Grok") == "grok-4"
+        assert provider._resolve_model_name("Grok") == "grok-4-1-fast-reasoning"  # cost-efficient default
         assert provider._resolve_model_name("GROK-4.1-FAST-REASONING") == "grok-4-1-fast-reasoning"
 
     def test_dial_provider_aliases(self):

--- a/tests/test_xai_provider.py
+++ b/tests/test_xai_provider.py
@@ -205,6 +205,7 @@ class TestXAIProvider:
         assert capabilities.supports_function_calling is True
         assert capabilities.supports_json_mode is True
         assert capabilities.supports_images is True
+        assert capabilities.allow_code_generation is False
 
         # Test temperature range
         assert capabilities.temperature_constraint.min_temp == 0.0
@@ -232,6 +233,7 @@ class TestXAIProvider:
         assert capabilities.supports_function_calling is True
         assert capabilities.supports_json_mode is True
         assert capabilities.supports_images is False
+        assert capabilities.allow_code_generation is False
 
         # Test temperature range
         assert capabilities.temperature_constraint.min_temp == 0.0
@@ -253,6 +255,7 @@ class TestXAIProvider:
         assert capabilities.supports_function_calling is True
         assert capabilities.supports_json_mode is True
         assert capabilities.supports_images is True
+        assert capabilities.allow_code_generation is False
 
         # Test temperature range
         assert capabilities.temperature_constraint.min_temp == 0.0
@@ -280,6 +283,7 @@ class TestXAIProvider:
         assert capabilities.supports_function_calling is True
         assert capabilities.supports_json_mode is True
         assert capabilities.supports_images is False
+        assert capabilities.allow_code_generation is False
 
         # Test temperature range
         assert capabilities.temperature_constraint.min_temp == 0.0
@@ -377,7 +381,7 @@ class TestXAIProvider:
         # grok-4-fast should be blocked by restrictions
         assert provider.validate_model_name("grok-4-fast") is False
 
-    @patch.dict(os.environ, {"XAI_ALLOWED_MODELS": "grok,grok-4-fast"})
+    @patch.dict(os.environ, {"XAI_API_KEY": "test-key", "XAI_ALLOWED_MODELS": "grok,grok-4-fast"})
     def test_multiple_model_restrictions(self):
         """Test multiple models in restrictions."""
         # Clear cached restriction service

--- a/tests/test_xai_provider.py
+++ b/tests/test_xai_provider.py
@@ -44,38 +44,130 @@ class TestXAIProvider:
         """Test model name validation."""
         provider = XAIModelProvider("test-key")
 
-        # Test valid models
+        # Test valid models - canonical names
         assert provider.validate_model_name("grok-4") is True
+        assert provider.validate_model_name("grok-4-1-fast-reasoning") is True
+        assert provider.validate_model_name("grok-4-1-fast-non-reasoning") is True
+        assert provider.validate_model_name("grok-4-fast") is True
+        assert provider.validate_model_name("grok-4-fast-non-reasoning") is True
+        assert provider.validate_model_name("grok-code-fast-1") is True
+
+        # Test valid models - common aliases
         assert provider.validate_model_name("grok4") is True
         assert provider.validate_model_name("grok") is True
+        assert provider.validate_model_name("grok-4-1-fast") is True
         assert provider.validate_model_name("grok-4.1-fast") is True
-        assert provider.validate_model_name("grok-4.1-fast-reasoning") is True
-        assert provider.validate_model_name("grok-4.1-fast-reasoning-latest") is True
-        assert provider.validate_model_name("grok-4.1-fast") is True
-        assert provider.validate_model_name("grok-4.1-fast-reasoning") is True
-        assert provider.validate_model_name("grok-4.1-fast-reasoning-latest") is True
+        assert provider.validate_model_name("grok-4-fast-reasoning") is True
+        assert provider.validate_model_name("grok4fast") is True
+        assert provider.validate_model_name("grok-code-fast") is True
+        assert provider.validate_model_name("grokcodefast") is True
 
         # Test invalid model
         assert provider.validate_model_name("invalid-model") is False
         assert provider.validate_model_name("gpt-4") is False
         assert provider.validate_model_name("gemini-pro") is False
-        assert provider.validate_model_name("grok-3") is False
-        assert provider.validate_model_name("grok-3-fast") is False
-        assert provider.validate_model_name("grokfast") is False
+
+    def test_model_validation_all_aliases(self):
+        """Test that ALL aliases defined in xai_models.json are valid.
+
+        This ensures comprehensive validation coverage of every alias.
+        """
+        provider = XAIModelProvider("test-key")
+
+        # All aliases from xai_models.json should be valid
+        all_aliases = [
+            # grok-4 aliases
+            "grok4",
+            # grok-4-1-fast-reasoning aliases
+            "grok",
+            "grok-4.1",
+            "grok-4-1",
+            "grok-4.1-fast-reasoning",
+            "grok-4.1-fast-reasoning-latest",
+            "grok-4.1-fast",
+            "grok-4-1-fast",
+            # grok-4-1-fast-non-reasoning aliases
+            "grok-4.1-fast-non-reasoning",
+            "grok-4-1-fast-non-reasoning-latest",
+            # grok-4-fast aliases
+            "grok-4-fast-reasoning",
+            "grok-4-fast-reasoning-latest",
+            "grok4fast",
+            # grok-4-fast-non-reasoning aliases
+            "grok-4-fast-non-reasoning-latest",
+            # grok-code-fast-1 aliases
+            "grok-code-fast",
+            "grok-code-fast-1-0825",
+            "grokcodefast",
+        ]
+
+        for alias in all_aliases:
+            assert provider.validate_model_name(alias) is True, f"Alias '{alias}' should be valid"
 
     def test_resolve_model_name(self):
         """Test model name resolution."""
         provider = XAIModelProvider("test-key")
 
-        # Test shorthand resolution
-        assert provider._resolve_model_name("grok") == "grok-4"
+        # Test shorthand resolution - 'grok' now resolves to cost-efficient model
+        assert provider._resolve_model_name("grok") == "grok-4-1-fast-reasoning"
         assert provider._resolve_model_name("grok4") == "grok-4"
+        assert provider._resolve_model_name("grok-4-1-fast") == "grok-4-1-fast-reasoning"
+        assert provider._resolve_model_name("grok-4.1-fast") == "grok-4-1-fast-reasoning"
         assert provider._resolve_model_name("grok-4.1-fast-reasoning") == "grok-4-1-fast-reasoning"
-        assert provider._resolve_model_name("grok-4.1-fast-reasoning-latest") == "grok-4-1-fast-reasoning"
+        assert provider._resolve_model_name("grok-4-1-fast-non-reasoning") == "grok-4-1-fast-non-reasoning"
+        assert provider._resolve_model_name("grok-4-fast") == "grok-4-fast"
+        assert provider._resolve_model_name("grok-4-fast-reasoning") == "grok-4-fast"
+        assert provider._resolve_model_name("grok-4-fast-non-reasoning") == "grok-4-fast-non-reasoning"
+        assert provider._resolve_model_name("grok4fast") == "grok-4-fast"
+        assert provider._resolve_model_name("grok-code-fast") == "grok-code-fast-1"
+        assert provider._resolve_model_name("grokcodefast") == "grok-code-fast-1"
 
         # Test full name passthrough
         assert provider._resolve_model_name("grok-4") == "grok-4"
+
+    def test_resolve_model_name_all_aliases(self):
+        """Test that ALL aliases defined in xai_models.json resolve correctly.
+
+        This ensures comprehensive coverage of every alias defined in the config.
+        """
+        provider = XAIModelProvider("test-key")
+
+        # grok-4 aliases
+        assert provider._resolve_model_name("grok4") == "grok-4"
+
+        # grok-4-1-fast-reasoning aliases (includes default 'grok' alias)
+        assert provider._resolve_model_name("grok") == "grok-4-1-fast-reasoning"
+        assert provider._resolve_model_name("grok-4.1") == "grok-4-1-fast-reasoning"
+        assert provider._resolve_model_name("grok-4-1") == "grok-4-1-fast-reasoning"
+        assert provider._resolve_model_name("grok-4.1-fast-reasoning") == "grok-4-1-fast-reasoning"
+        assert provider._resolve_model_name("grok-4.1-fast-reasoning-latest") == "grok-4-1-fast-reasoning"
         assert provider._resolve_model_name("grok-4.1-fast") == "grok-4-1-fast-reasoning"
+        assert provider._resolve_model_name("grok-4-1-fast") == "grok-4-1-fast-reasoning"
+
+        # grok-4-1-fast-non-reasoning aliases
+        assert provider._resolve_model_name("grok-4.1-fast-non-reasoning") == "grok-4-1-fast-non-reasoning"
+        assert provider._resolve_model_name("grok-4-1-fast-non-reasoning-latest") == "grok-4-1-fast-non-reasoning"
+
+        # grok-4-fast aliases
+        assert provider._resolve_model_name("grok-4-fast-reasoning") == "grok-4-fast"
+        assert provider._resolve_model_name("grok-4-fast-reasoning-latest") == "grok-4-fast"
+        assert provider._resolve_model_name("grok4fast") == "grok-4-fast"
+
+        # grok-4-fast-non-reasoning aliases
+        assert provider._resolve_model_name("grok-4-fast-non-reasoning-latest") == "grok-4-fast-non-reasoning"
+
+        # grok-code-fast-1 aliases
+        assert provider._resolve_model_name("grok-code-fast") == "grok-code-fast-1"
+        assert provider._resolve_model_name("grok-code-fast-1-0825") == "grok-code-fast-1"
+        assert provider._resolve_model_name("grokcodefast") == "grok-code-fast-1"
+
+        # Canonical model names should pass through unchanged
+        assert provider._resolve_model_name("grok-4") == "grok-4"
+        assert provider._resolve_model_name("grok-4-1-fast-reasoning") == "grok-4-1-fast-reasoning"
+        assert provider._resolve_model_name("grok-4-1-fast-non-reasoning") == "grok-4-1-fast-non-reasoning"
+        assert provider._resolve_model_name("grok-4-fast") == "grok-4-fast"
+        assert provider._resolve_model_name("grok-4-fast-non-reasoning") == "grok-4-fast-non-reasoning"
+        assert provider._resolve_model_name("grok-code-fast-1") == "grok-code-fast-1"
 
     def test_get_capabilities_grok4(self):
         """Test getting model capabilities for GROK-4."""
@@ -98,30 +190,135 @@ class TestXAIProvider:
         assert capabilities.temperature_constraint.max_temp == 2.0
         assert capabilities.temperature_constraint.default_temp == 0.3
 
-    def test_get_capabilities_grok4_1_fast(self):
+    def test_get_capabilities_grok4_1_fast_reasoning(self):
         """Test getting model capabilities for GROK-4.1 Fast Reasoning."""
         provider = XAIModelProvider("test-key")
 
-        capabilities = provider.get_capabilities("grok-4.1-fast")
+        capabilities = provider.get_capabilities("grok-4-1-fast-reasoning")
         assert capabilities.model_name == "grok-4-1-fast-reasoning"
         assert capabilities.friendly_name == "X.AI (Grok 4.1 Fast Reasoning)"
         assert capabilities.context_window == 2_000_000
         assert capabilities.provider == ProviderType.XAI
         assert capabilities.supports_extended_thinking is True
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
         assert capabilities.supports_function_calling is True
         assert capabilities.supports_json_mode is True
         assert capabilities.supports_images is True
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
+
+        # Test that aliases with '.' and '-' resolve correctly
+        for alias in ["grok-4.1-fast", "grok-4-1-fast"]:
+            capabilities_alias = provider.get_capabilities(alias)
+            assert capabilities_alias.model_name == "grok-4-1-fast-reasoning"
+            assert capabilities_alias.friendly_name == "X.AI (Grok 4.1 Fast Reasoning)"
+
+    def test_get_capabilities_grok4_1_fast_non_reasoning(self):
+        """Test getting model capabilities for GROK-4.1 Fast Non-Reasoning."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-4-1-fast-non-reasoning")
+        assert capabilities.model_name == "grok-4-1-fast-non-reasoning"
+        assert capabilities.friendly_name == "X.AI (Grok 4.1 Fast Non-Reasoning)"
+        assert capabilities.context_window == 2_000_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is False
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is False
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
+
+    def test_get_capabilities_grok4_fast_reasoning(self):
+        """Test getting model capabilities for GROK-4 Fast Reasoning."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-4-fast")
+        assert capabilities.model_name == "grok-4-fast"
+        assert capabilities.friendly_name == "X.AI (Grok 4 Fast Reasoning)"
+        assert capabilities.context_window == 2_000_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is True
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is True
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
+
+        # Test that aliases resolve correctly
+        for alias in ["grok-4-fast-reasoning", "grok4fast"]:
+            capabilities_alias = provider.get_capabilities(alias)
+            assert capabilities_alias.model_name == "grok-4-fast"
+            assert capabilities_alias.friendly_name == "X.AI (Grok 4 Fast Reasoning)"
+
+    def test_get_capabilities_grok4_fast_non_reasoning(self):
+        """Test getting model capabilities for GROK-4 Fast Non-Reasoning."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-4-fast-non-reasoning")
+        assert capabilities.model_name == "grok-4-fast-non-reasoning"
+        assert capabilities.friendly_name == "X.AI (Grok 4 Fast Non-Reasoning)"
+        assert capabilities.context_window == 2_000_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is False
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is False
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
+
+    def test_get_capabilities_grok_code_fast_1(self):
+        """Test getting model capabilities for GROK Code Fast 1."""
+        provider = XAIModelProvider("test-key")
+
+        capabilities = provider.get_capabilities("grok-code-fast-1")
+        assert capabilities.model_name == "grok-code-fast-1"
+        assert capabilities.friendly_name == "X.AI (Grok Code Fast 1)"
+        assert capabilities.context_window == 256_000
+        assert capabilities.provider == ProviderType.XAI
+        assert capabilities.supports_extended_thinking is True
+        assert capabilities.supports_system_prompts is True
+        assert capabilities.supports_streaming is True
+        assert capabilities.supports_function_calling is True
+        assert capabilities.supports_json_mode is True
+        assert capabilities.supports_images is False
+        assert capabilities.allow_code_generation is True
+
+        # Test temperature range
+        assert capabilities.temperature_constraint.min_temp == 0.0
+        assert capabilities.temperature_constraint.max_temp == 2.0
+        assert capabilities.temperature_constraint.default_temp == 0.3
 
     def test_get_capabilities_with_shorthand(self):
         """Test getting model capabilities with shorthand."""
         provider = XAIModelProvider("test-key")
 
+        # 'grok' now resolves to cost-efficient grok-4-1-fast-reasoning
         capabilities = provider.get_capabilities("grok")
-        assert capabilities.model_name == "grok-4"  # Should resolve to full name
-        assert capabilities.context_window == 256_000
+        assert capabilities.model_name == "grok-4-1-fast-reasoning"
+        assert capabilities.context_window == 2_000_000
 
         capabilities_fast = provider.get_capabilities("grok-4.1-fast-reasoning")
-        assert capabilities_fast.model_name == "grok-4-1-fast-reasoning"  # Should resolve to full name
+        assert capabilities_fast.model_name == "grok-4-1-fast-reasoning"
 
     def test_unsupported_model_capabilities(self):
         """Test error handling for unsupported models."""
@@ -138,12 +335,20 @@ class TestXAIProvider:
             "grok-4",
             "grok",
             "grok4",
+            "grok-4-fast",
+            "grok-4-1-fast-reasoning",
             "grok-4.1-fast",
-            "grok-4.1-fast-reasoning",
-            "grok-4.1-fast-reasoning-latest",
+            "grok-code-fast-1",
         ]
         for alias in thinking_aliases:
             assert provider.get_capabilities(alias).supports_extended_thinking is True
+
+        non_thinking_aliases = [
+            "grok-4-fast-non-reasoning",
+            "grok-4-1-fast-non-reasoning",
+        ]
+        for alias in non_thinking_aliases:
+            assert provider.get_capabilities(alias).supports_extended_thinking is False
 
     def test_provider_type(self):
         """Test provider type identification."""
@@ -164,15 +369,17 @@ class TestXAIProvider:
 
         # grok-4 should be allowed (including alias)
         assert provider.validate_model_name("grok-4") is True
-        assert provider.validate_model_name("grok") is True
+        assert provider.validate_model_name("grok4") is True
 
-        # grok-4.1-fast should be blocked by restrictions
-        assert provider.validate_model_name("grok-4.1-fast") is False
-        assert provider.validate_model_name("grok-4.1-fast-reasoning") is False
+        # grok should be blocked (resolves to grok-4-1-fast-reasoning which is not allowed)
+        assert provider.validate_model_name("grok") is False
 
-    @patch.dict(os.environ, {"XAI_ALLOWED_MODELS": "grok-4.1-fast-reasoning"})
+        # grok-4-fast should be blocked by restrictions
+        assert provider.validate_model_name("grok-4-fast") is False
+
+    @patch.dict(os.environ, {"XAI_ALLOWED_MODELS": "grok,grok-4-fast"})
     def test_multiple_model_restrictions(self):
-        """Restrictions should allow aliases for Grok 4.1 Fast."""
+        """Test multiple models in restrictions."""
         # Clear cached restriction service
         import utils.model_restrictions
         from providers.registry import ModelProviderRegistry
@@ -182,18 +389,29 @@ class TestXAIProvider:
 
         provider = XAIModelProvider("test-key")
 
-        # Alias should be allowed (resolves to grok-4.1-fast)
-        assert provider.validate_model_name("grok-4.1-fast-reasoning") is True
+        # Shorthand "grok" should be allowed (resolves to grok-4-1-fast-reasoning)
+        assert provider.validate_model_name("grok") is True
 
-        # Canonical name is not allowed unless explicitly listed
-        assert provider.validate_model_name("grok-4.1-fast") is False
+        # Full name "grok-4-1-fast-reasoning" should NOT be allowed (only shorthand "grok" is in restriction list)
+        assert provider.validate_model_name("grok-4-1-fast-reasoning") is False
 
-        # grok-4 should NOT be allowed
+        # "grok-4" should NOT be allowed (not in restriction list)
         assert provider.validate_model_name("grok-4") is False
 
-    @patch.dict(os.environ, {"XAI_ALLOWED_MODELS": "grok,grok-4,grok-4.1-fast,grok-4-1-fast-reasoning"})
+        # "grok-4-fast" should be allowed (explicitly listed)
+        assert provider.validate_model_name("grok-4-fast") is True
+
+        # Shorthand "grok4fast" should be allowed (resolves to grok-4-fast)
+        assert provider.validate_model_name("grok4fast") is True
+
+    @patch.dict(
+        os.environ,
+        {
+            "XAI_ALLOWED_MODELS": "grok,grok-4-1-fast-reasoning,grok-4",
+        },
+    )
     def test_both_shorthand_and_full_name_allowed(self):
-        """Test that aliases and canonical names can be allowed together."""
+        """Test that both shorthand and full name can be allowed."""
         # Clear cached restriction service
         import utils.model_restrictions
 
@@ -201,11 +419,13 @@ class TestXAIProvider:
 
         provider = XAIModelProvider("test-key")
 
-        # Both shorthand and full name should be allowed when explicitly listed
-        assert provider.validate_model_name("grok") is True  # Alias explicitly allowed
-        assert provider.validate_model_name("grok-4") is True  # Canonical name explicitly allowed
-        assert provider.validate_model_name("grok-4.1-fast") is True  # Alias explicitly allowed
-        assert provider.validate_model_name("grok-4-1-fast-reasoning") is True  # Canonical name explicitly allowed
+        # Both shorthand and full name should be allowed
+        assert provider.validate_model_name("grok") is True  # Resolves to grok-4-1-fast-reasoning
+        assert provider.validate_model_name("grok-4") is True
+        assert provider.validate_model_name("grok-4-1-fast-reasoning") is True
+
+        # Other models should not be allowed
+        assert provider.validate_model_name("grok-4-fast") is False
 
     @patch.dict(os.environ, {"XAI_ALLOWED_MODELS": ""})
     def test_empty_restrictions_allows_all(self):
@@ -218,10 +438,10 @@ class TestXAIProvider:
         provider = XAIModelProvider("test-key")
 
         assert provider.validate_model_name("grok-4") is True
-        assert provider.validate_model_name("grok-4.1-fast") is True
-        assert provider.validate_model_name("grok-4.1-fast-reasoning") is True
         assert provider.validate_model_name("grok") is True
         assert provider.validate_model_name("grok4") is True
+        assert provider.validate_model_name("grok-4-fast") is True
+        assert provider.validate_model_name("grok-code-fast-1") is True
 
     def test_friendly_name(self):
         """Test friendly name constant."""
@@ -238,6 +458,10 @@ class TestXAIProvider:
         # Check that all expected base models are present
         assert "grok-4" in provider.MODEL_CAPABILITIES
         assert "grok-4-1-fast-reasoning" in provider.MODEL_CAPABILITIES
+        assert "grok-4-1-fast-non-reasoning" in provider.MODEL_CAPABILITIES
+        assert "grok-4-fast" in provider.MODEL_CAPABILITIES
+        assert "grok-4-fast-non-reasoning" in provider.MODEL_CAPABILITIES
+        assert "grok-code-fast-1" in provider.MODEL_CAPABILITIES
 
         # Check model configs have required fields
         from providers.shared import ModelCapabilities
@@ -251,22 +475,47 @@ class TestXAIProvider:
         assert grok4_config.supports_extended_thinking is True
 
         # Check aliases are correctly structured
-        assert "grok" in grok4_config.aliases
-        assert "grok-4" in grok4_config.aliases
         assert "grok4" in grok4_config.aliases
 
-        grok41fast_config = provider.MODEL_CAPABILITIES["grok-4-1-fast-reasoning"]
-        assert grok41fast_config.context_window == 2_000_000
-        assert grok41fast_config.supports_extended_thinking is True
-        assert "grok-4.1-fast" in grok41fast_config.aliases
-        assert "grok-4.1-fast-reasoning" in grok41fast_config.aliases
+        # Check grok-4 aliases (grok alias moved to grok-4-1-fast-reasoning)
+        assert "grok" not in grok4_config.aliases  # grok now resolves to grok-4-1-fast-reasoning
+
+        # Check new Grok-4-1 Fast models
+        grok4_1_fast_config = provider.MODEL_CAPABILITIES["grok-4-1-fast-reasoning"]
+        assert grok4_1_fast_config.context_window == 2_000_000
+        assert grok4_1_fast_config.supports_extended_thinking is True
+        assert "grok" in grok4_1_fast_config.aliases  # grok now resolves to grok-4-1-fast-reasoning
+        assert "grok-4-1-fast" in grok4_1_fast_config.aliases
+        assert "grok-4.1-fast" in grok4_1_fast_config.aliases
+
+        grok4_1_fast_non_reasoning_config = provider.MODEL_CAPABILITIES["grok-4-1-fast-non-reasoning"]
+        assert grok4_1_fast_non_reasoning_config.context_window == 2_000_000
+        assert grok4_1_fast_non_reasoning_config.supports_extended_thinking is False
+
+        # Check new Grok-4 Fast models
+        grok4_fast_config = provider.MODEL_CAPABILITIES["grok-4-fast"]
+        assert grok4_fast_config.context_window == 2_000_000
+        assert grok4_fast_config.supports_extended_thinking is True
+        assert "grok-4-fast-reasoning" in grok4_fast_config.aliases
+        assert "grok4fast" in grok4_fast_config.aliases
+
+        grok4_fast_non_reasoning_config = provider.MODEL_CAPABILITIES["grok-4-fast-non-reasoning"]
+        assert grok4_fast_non_reasoning_config.context_window == 2_000_000
+        assert grok4_fast_non_reasoning_config.supports_extended_thinking is False
+
+        grok_code_fast_config = provider.MODEL_CAPABILITIES["grok-code-fast-1"]
+        assert grok_code_fast_config.context_window == 256_000
+        assert grok_code_fast_config.supports_extended_thinking is True
+        assert grok_code_fast_config.allow_code_generation is True
+        assert "grok-code-fast" in grok_code_fast_config.aliases
+        assert "grokcodefast" in grok_code_fast_config.aliases
 
     @patch("providers.openai_compatible.OpenAI")
     def test_generate_content_resolves_alias_before_api_call(self, mock_openai_class):
         """Test that generate_content resolves aliases before making API calls.
 
         This is the CRITICAL test that ensures aliases like 'grok' get resolved
-        to 'grok-4' before being sent to X.AI API.
+        to 'grok-4-1-fast-reasoning' before being sent to X.AI API.
         """
         # Set up mock OpenAI client
         mock_client = MagicMock()
@@ -277,7 +526,7 @@ class TestXAIProvider:
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Test response"
         mock_response.choices[0].finish_reason = "stop"
-        mock_response.model = "grok-4"  # API returns the resolved model name
+        mock_response.model = "grok-4-1-fast-reasoning"  # API returns the resolved model name
         mock_response.id = "test-id"
         mock_response.created = 1234567890
         mock_response.usage = MagicMock()
@@ -291,15 +540,19 @@ class TestXAIProvider:
 
         # Call generate_content with alias 'grok'
         result = provider.generate_content(
-            prompt="Test prompt", model_name="grok", temperature=0.7  # This should be resolved to "grok-4"
+            prompt="Test prompt",
+            model_name="grok",
+            temperature=0.7,  # This should be resolved to "grok-4-1-fast-reasoning"
         )
 
         # Verify the API was called with the RESOLVED model name
         mock_client.chat.completions.create.assert_called_once()
         call_kwargs = mock_client.chat.completions.create.call_args[1]
 
-        # CRITICAL ASSERTION: The API should receive "grok-4", not "grok"
-        assert call_kwargs["model"] == "grok-4", f"Expected 'grok-4' but API received '{call_kwargs['model']}'"
+        # CRITICAL ASSERTION: The API should receive "grok-4-1-fast-reasoning", not "grok"
+        assert (
+            call_kwargs["model"] == "grok-4-1-fast-reasoning"
+        ), f"Expected 'grok-4-1-fast-reasoning' but API received '{call_kwargs['model']}'"
 
         # Verify other parameters
         assert call_kwargs["temperature"] == 0.7
@@ -309,7 +562,7 @@ class TestXAIProvider:
 
         # Verify response
         assert result.content == "Test response"
-        assert result.model_name == "grok-4"  # Should be the resolved name
+        assert result.model_name == "grok-4-1-fast-reasoning"  # Should be the resolved name
 
     @patch("providers.openai_compatible.OpenAI")
     def test_generate_content_other_aliases(self, mock_openai_class):
@@ -342,13 +595,14 @@ class TestXAIProvider:
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs["model"] == "grok-4"
 
-        # Test grok-4.1-fast-reasoning -> grok-4-1-fast-reasoning
-        mock_response.model = "grok-4-1-fast-reasoning"
-        provider.generate_content(prompt="Test", model_name="grok-4.1-fast-reasoning", temperature=0.7)
-        call_kwargs = mock_client.chat.completions.create.call_args[1]
-        assert call_kwargs["model"] == "grok-4-1-fast-reasoning"
-
         # Test grok-4.1-fast -> grok-4-1-fast-reasoning
+        mock_response.model = "grok-4-1-fast-reasoning"
         provider.generate_content(prompt="Test", model_name="grok-4.1-fast", temperature=0.7)
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs["model"] == "grok-4-1-fast-reasoning"
+
+        # Test grok4fast -> grok-4-fast
+        mock_response.model = "grok-4-fast"
+        provider.generate_content(prompt="Test", model_name="grok4fast", temperature=0.7)
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["model"] == "grok-4-fast"


### PR DESCRIPTION
## Description

Adds X.AI Grok 4 Fast model variants to enable cost-efficient AI workflows with up to 98% cost reduction while maintaining comparable performance.

## Changes Made

- [x] Added 4 new Grok model variants to `conf/xai_models.json`:
  - `grok-4-1-fast-non-reasoning` - Ultra-fast text generation without reasoning
  - `grok-4-fast` - Cost-efficient frontier reasoning (98% lower cost vs Grok 4)
  - `grok-4-fast-non-reasoning` - Ultra-fast text generation
  - `grok-code-fast-1` - Specialized for agentic coding workflows
- [x] Changed default `grok` alias to resolve to `grok-4-1-fast-reasoning` for cost savings
- [x] Added `allow_code_generation` field for coding-specialized models
- [x] No breaking changes - existing model names continue to work
- [x] No new dependencies

## Testing

- [x] All linting passes (ruff, black, isort)
- [x] All unit tests pass
- [x] **For new features**: Unit tests added in `tests/`
- [x] Comprehensive test coverage for all new model aliases and capabilities

## Related Issues

N/A - Feature addition

## Checklist

- [x] PR title follows the format guidelines above
- [x] **Activated venv and ran code quality checks**
- [x] Self-review completed
- [x] **Tests added for ALL changes**
- [x] All unit tests passing
- [x] Ready for review

## Additional Notes

The `grok` shorthand alias now defaults to `grok-4-1-fast-reasoning` instead of `grok-4` to optimize for cost efficiency. Users can still access the full Grok 4 model via `grok4` or `grok-4` aliases.