### PR TITLE
chore(config): sync clink client configurations with hestai-mcp-server

### DIFF
--- a/conf/cli_clients/claude.json
+++ b/conf/cli_clients/claude.json
@@ -3,23 +3,389 @@
   "command": "claude",
   "additional_args": [
     "--permission-mode",
-    "acceptEdits",
-    "--model",
-    "sonnet"
+    "bypassPermissions"
   ],
   "env": {},
   "roles": {
+    "holistic-orchestrator": {
+      "prompt_path": "systemprompts/clink/holistic-orchestrator.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "critical-engineer": {
+      "prompt_path": "systemprompts/clink/critical-engineer.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "critical-design-validator": {
+      "prompt_path": "systemprompts/clink/critical-design-validator.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "critical-implementation-validator": {
+      "prompt_path": "systemprompts/clink/critical-implementation-validator.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "requirements-steward": {
+      "prompt_path": "systemprompts/clink/requirements-steward.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "security-specialist": {
+      "prompt_path": "systemprompts/clink/security-specialist.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "coherence-oracle": {
+      "prompt_path": "systemprompts/clink/coherence-oracle.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "test-methodology-guardian": {
+      "prompt_path": "systemprompts/clink/test-methodology-guardian.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "universal-test-engineer": {
+      "prompt_path": "systemprompts/clink/universal-test-engineer.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "test-infrastructure-steward": {
+      "prompt_path": "systemprompts/clink/test-infrastructure-steward.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "build-plan-checker": {
+      "prompt_path": "systemprompts/clink/build-plan-checker.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "code-review-specialist": {
+      "prompt_path": "systemprompts/clink/code-review-specialist.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "quality-observer": {
+      "prompt_path": "systemprompts/clink/quality-observer.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "validator": {
+      "prompt_path": "systemprompts/clink/validator.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "blind-assessor": {
+      "prompt_path": "systemprompts/clink/blind-assessor.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "north-star-architect": {
+      "prompt_path": "systemprompts/clink/north-star-architect.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "technical-architect": {
+      "prompt_path": "systemprompts/clink/technical-architect.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "design-architect": {
+      "prompt_path": "systemprompts/clink/design-architect.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "visual-architect": {
+      "prompt_path": "systemprompts/clink/visual-architect.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "workspace-architect": {
+      "prompt_path": "systemprompts/clink/workspace-architect.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "completion-architect": {
+      "prompt_path": "systemprompts/clink/completion-architect.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "implementation-lead": {
+      "prompt_path": "systemprompts/clink/implementation-lead.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "principal-engineer": {
+      "prompt_path": "systemprompts/clink/principal-engineer.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "error-architect": {
+      "prompt_path": "systemprompts/clink/error-architect.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "error-architect-surface": {
+      "prompt_path": "systemprompts/clink/error-architect-surface.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "directory-curator": {
+      "prompt_path": "systemprompts/clink/directory-curator.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "surveyor": {
+      "prompt_path": "systemprompts/clink/surveyor.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "research-analyst": {
+      "prompt_path": "systemprompts/clink/research-analyst.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "research-curator": {
+      "prompt_path": "systemprompts/clink/research-curator.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "ho-liaison": {
+      "prompt_path": "systemprompts/clink/ho-liaison.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "ideator": {
+      "prompt_path": "systemprompts/clink/ideator.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "ideator-catalyst": {
+      "prompt_path": "systemprompts/clink/ideator-catalyst.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "idea-clarifier": {
+      "prompt_path": "systemprompts/clink/idea-clarifier.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "synthesizer": {
+      "prompt_path": "systemprompts/clink/synthesizer.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "edge-optimizer": {
+      "prompt_path": "systemprompts/clink/edge-optimizer.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "complexity-guard": {
+      "prompt_path": "systemprompts/clink/complexity-guard.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "octave-specialist": {
+      "prompt_path": "systemprompts/clink/octave-specialist.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "octave-validator": {
+      "prompt_path": "systemprompts/clink/octave-validator.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "semantic-optimizer": {
+      "prompt_path": "systemprompts/clink/semantic-optimizer.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "documentation-compressor": {
+      "prompt_path": "systemprompts/clink/documentation-compressor.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "compression-fidelity-validator": {
+      "prompt_path": "systemprompts/clink/compression-fidelity-validator.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "hestai-doc-steward": {
+      "prompt_path": "systemprompts/clink/hestai-doc-steward.txt",
+      "role_args": [
+        "--model",
+        "opus"
+      ]
+    },
+    "task-decomposer": {
+      "prompt_path": "systemprompts/clink/task-decomposer.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "task-decomposer-validator": {
+      "prompt_path": "systemprompts/clink/task-decomposer-validator.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "smartsuite-expert": {
+      "prompt_path": "systemprompts/clink/smartsuite-expert.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "supabase-expert": {
+      "prompt_path": "systemprompts/clink/supabase-expert.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "skills-expert": {
+      "prompt_path": "systemprompts/clink/skills-expert.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "subagent-creator": {
+      "prompt_path": "systemprompts/clink/subagent-creator.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "system-steward": {
+      "prompt_path": "systemprompts/clink/system-steward.txt",
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
+    },
+    "solution-steward": {
+      "prompt_path": "systemprompts/clink/solution-steward.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
+    "vibe-coder": {
+      "prompt_path": "systemprompts/clink/vibe-coder.txt",
+      "role_args": [
+        "--model",
+        "sonnet"
+      ]
+    },
     "default": {
       "prompt_path": "systemprompts/clink/default.txt",
-      "role_args": []
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
     },
     "planner": {
       "prompt_path": "systemprompts/clink/default_planner.txt",
-      "role_args": []
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
     },
     "codereviewer": {
       "prompt_path": "systemprompts/clink/default_codereviewer.txt",
-      "role_args": []
+      "role_args": [
+        "--model",
+        "haiku"
+      ]
     }
-  }
+  },
+  "_generated_by": "scripts/generate_client_configs.py",
+  "_tier_mapping_version": "1.0.0"
 }

--- a/conf/cli_clients/codex.json
+++ b/conf/cli_clients/codex.json
@@ -1,14 +1,216 @@
 {
   "name": "codex",
   "command": "codex",
+  "timeout_seconds": 900,
   "additional_args": [
+    "--model",
+    "gpt-5.2",
     "--json",
     "--dangerously-bypass-approvals-and-sandbox",
-    "--enable",
-    "web_search_request"
+    "--skip-git-repo-check"
   ],
   "env": {},
   "roles": {
+    "critical-engineer": {
+      "prompt_path": "systemprompts/clink/critical-engineer.txt",
+      "role_args": []
+    },
+    "critical-design-validator": {
+      "prompt_path": "systemprompts/clink/critical-design-validator.txt",
+      "role_args": []
+    },
+    "critical-implementation-validator": {
+      "prompt_path": "systemprompts/clink/critical-implementation-validator.txt",
+      "role_args": []
+    },
+    "requirements-steward": {
+      "prompt_path": "systemprompts/clink/requirements-steward.txt",
+      "role_args": []
+    },
+    "security-specialist": {
+      "prompt_path": "systemprompts/clink/security-specialist.txt",
+      "role_args": []
+    },
+    "coherence-oracle": {
+      "prompt_path": "systemprompts/clink/coherence-oracle.txt",
+      "role_args": []
+    },
+    "test-methodology-guardian": {
+      "prompt_path": "systemprompts/clink/test-methodology-guardian.txt",
+      "role_args": []
+    },
+    "universal-test-engineer": {
+      "prompt_path": "systemprompts/clink/universal-test-engineer.txt",
+      "role_args": []
+    },
+    "test-infrastructure-steward": {
+      "prompt_path": "systemprompts/clink/test-infrastructure-steward.txt",
+      "role_args": []
+    },
+    "build-plan-checker": {
+      "prompt_path": "systemprompts/clink/build-plan-checker.txt",
+      "role_args": []
+    },
+    "code-review-specialist": {
+      "prompt_path": "systemprompts/clink/code-review-specialist.txt",
+      "role_args": []
+    },
+    "quality-observer": {
+      "prompt_path": "systemprompts/clink/quality-observer.txt",
+      "role_args": []
+    },
+    "validator": {
+      "prompt_path": "systemprompts/clink/validator.txt",
+      "role_args": []
+    },
+    "blind-assessor": {
+      "prompt_path": "systemprompts/clink/blind-assessor.txt",
+      "role_args": []
+    },
+    "north-star-architect": {
+      "prompt_path": "systemprompts/clink/north-star-architect.txt",
+      "role_args": []
+    },
+    "technical-architect": {
+      "prompt_path": "systemprompts/clink/technical-architect.txt",
+      "role_args": []
+    },
+    "design-architect": {
+      "prompt_path": "systemprompts/clink/design-architect.txt",
+      "role_args": []
+    },
+    "visual-architect": {
+      "prompt_path": "systemprompts/clink/visual-architect.txt",
+      "role_args": []
+    },
+    "workspace-architect": {
+      "prompt_path": "systemprompts/clink/workspace-architect.txt",
+      "role_args": []
+    },
+    "completion-architect": {
+      "prompt_path": "systemprompts/clink/completion-architect.txt",
+      "role_args": []
+    },
+    "implementation-lead": {
+      "prompt_path": "systemprompts/clink/implementation-lead.txt",
+      "role_args": []
+    },
+    "principal-engineer": {
+      "prompt_path": "systemprompts/clink/principal-engineer.txt",
+      "role_args": []
+    },
+    "error-architect": {
+      "prompt_path": "systemprompts/clink/error-architect.txt",
+      "role_args": []
+    },
+    "error-architect-surface": {
+      "prompt_path": "systemprompts/clink/error-architect-surface.txt",
+      "role_args": []
+    },
+    "directory-curator": {
+      "prompt_path": "systemprompts/clink/directory-curator.txt",
+      "role_args": []
+    },
+    "surveyor": {
+      "prompt_path": "systemprompts/clink/surveyor.txt",
+      "role_args": []
+    },
+    "research-analyst": {
+      "prompt_path": "systemprompts/clink/research-analyst.txt",
+      "role_args": []
+    },
+    "research-curator": {
+      "prompt_path": "systemprompts/clink/research-curator.txt",
+      "role_args": []
+    },
+    "ho-liaison": {
+      "prompt_path": "systemprompts/clink/ho-liaison.txt",
+      "role_args": []
+    },
+    "ideator": {
+      "prompt_path": "systemprompts/clink/ideator.txt",
+      "role_args": []
+    },
+    "ideator-catalyst": {
+      "prompt_path": "systemprompts/clink/ideator-catalyst.txt",
+      "role_args": []
+    },
+    "idea-clarifier": {
+      "prompt_path": "systemprompts/clink/idea-clarifier.txt",
+      "role_args": []
+    },
+    "synthesizer": {
+      "prompt_path": "systemprompts/clink/synthesizer.txt",
+      "role_args": []
+    },
+    "edge-optimizer": {
+      "prompt_path": "systemprompts/clink/edge-optimizer.txt",
+      "role_args": []
+    },
+    "complexity-guard": {
+      "prompt_path": "systemprompts/clink/complexity-guard.txt",
+      "role_args": []
+    },
+    "octave-specialist": {
+      "prompt_path": "systemprompts/clink/octave-specialist.txt",
+      "role_args": []
+    },
+    "octave-validator": {
+      "prompt_path": "systemprompts/clink/octave-validator.txt",
+      "role_args": []
+    },
+    "semantic-optimizer": {
+      "prompt_path": "systemprompts/clink/semantic-optimizer.txt",
+      "role_args": []
+    },
+    "documentation-compressor": {
+      "prompt_path": "systemprompts/clink/documentation-compressor.txt",
+      "role_args": []
+    },
+    "compression-fidelity-validator": {
+      "prompt_path": "systemprompts/clink/compression-fidelity-validator.txt",
+      "role_args": []
+    },
+    "hestai-doc-steward": {
+      "prompt_path": "systemprompts/clink/hestai-doc-steward.txt",
+      "role_args": []
+    },
+    "task-decomposer": {
+      "prompt_path": "systemprompts/clink/task-decomposer.txt",
+      "role_args": []
+    },
+    "task-decomposer-validator": {
+      "prompt_path": "systemprompts/clink/task-decomposer-validator.txt",
+      "role_args": []
+    },
+    "smartsuite-expert": {
+      "prompt_path": "systemprompts/clink/smartsuite-expert.txt",
+      "role_args": []
+    },
+    "supabase-expert": {
+      "prompt_path": "systemprompts/clink/supabase-expert.txt",
+      "role_args": []
+    },
+    "skills-expert": {
+      "prompt_path": "systemprompts/clink/skills-expert.txt",
+      "role_args": []
+    },
+    "subagent-creator": {
+      "prompt_path": "systemprompts/clink/subagent-creator.txt",
+      "role_args": []
+    },
+    "system-steward": {
+      "prompt_path": "systemprompts/clink/system-steward.txt",
+      "role_args": []
+    },
+    "solution-steward": {
+      "prompt_path": "systemprompts/clink/solution-steward.txt",
+      "role_args": []
+    },
+    "vibe-coder": {
+      "prompt_path": "systemprompts/clink/vibe-coder.txt",
+      "role_args": []
+    },
     "default": {
       "prompt_path": "systemprompts/clink/default.txt",
       "role_args": []
@@ -21,5 +223,7 @@
       "prompt_path": "systemprompts/clink/codex_codereviewer.txt",
       "role_args": []
     }
-  }
+  },
+  "_generated_by": "scripts/generate_client_configs.py",
+  "_tier_mapping_version": "1.0.0"
 }

--- a/conf/cli_clients/gemini.json
+++ b/conf/cli_clients/gemini.json
@@ -1,22 +1,374 @@
 {
   "name": "gemini",
   "command": "gemini",
-  "additional_args": [
-    "--yolo"
-  ],
+  "additional_args": [],
   "env": {},
   "roles": {
+    "critical-engineer": {
+      "prompt_path": "systemprompts/clink/critical-engineer.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "critical-design-validator": {
+      "prompt_path": "systemprompts/clink/critical-design-validator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "critical-implementation-validator": {
+      "prompt_path": "systemprompts/clink/critical-implementation-validator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "requirements-steward": {
+      "prompt_path": "systemprompts/clink/requirements-steward.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "security-specialist": {
+      "prompt_path": "systemprompts/clink/security-specialist.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "coherence-oracle": {
+      "prompt_path": "systemprompts/clink/coherence-oracle.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "test-methodology-guardian": {
+      "prompt_path": "systemprompts/clink/test-methodology-guardian.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "universal-test-engineer": {
+      "prompt_path": "systemprompts/clink/universal-test-engineer.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "test-infrastructure-steward": {
+      "prompt_path": "systemprompts/clink/test-infrastructure-steward.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "build-plan-checker": {
+      "prompt_path": "systemprompts/clink/build-plan-checker.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "code-review-specialist": {
+      "prompt_path": "systemprompts/clink/code-review-specialist.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "quality-observer": {
+      "prompt_path": "systemprompts/clink/quality-observer.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "validator": {
+      "prompt_path": "systemprompts/clink/validator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "blind-assessor": {
+      "prompt_path": "systemprompts/clink/blind-assessor.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "north-star-architect": {
+      "prompt_path": "systemprompts/clink/north-star-architect.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "technical-architect": {
+      "prompt_path": "systemprompts/clink/technical-architect.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "design-architect": {
+      "prompt_path": "systemprompts/clink/design-architect.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "visual-architect": {
+      "prompt_path": "systemprompts/clink/visual-architect.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "workspace-architect": {
+      "prompt_path": "systemprompts/clink/workspace-architect.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "completion-architect": {
+      "prompt_path": "systemprompts/clink/completion-architect.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "implementation-lead": {
+      "prompt_path": "systemprompts/clink/implementation-lead.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "principal-engineer": {
+      "prompt_path": "systemprompts/clink/principal-engineer.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "error-architect": {
+      "prompt_path": "systemprompts/clink/error-architect.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "error-architect-surface": {
+      "prompt_path": "systemprompts/clink/error-architect-surface.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "directory-curator": {
+      "prompt_path": "systemprompts/clink/directory-curator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "surveyor": {
+      "prompt_path": "systemprompts/clink/surveyor.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "research-analyst": {
+      "prompt_path": "systemprompts/clink/research-analyst.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "research-curator": {
+      "prompt_path": "systemprompts/clink/research-curator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "ho-liaison": {
+      "prompt_path": "systemprompts/clink/ho-liaison.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "ideator": {
+      "prompt_path": "systemprompts/clink/ideator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "ideator-catalyst": {
+      "prompt_path": "systemprompts/clink/ideator-catalyst.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "idea-clarifier": {
+      "prompt_path": "systemprompts/clink/idea-clarifier.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "synthesizer": {
+      "prompt_path": "systemprompts/clink/synthesizer.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "edge-optimizer": {
+      "prompt_path": "systemprompts/clink/edge-optimizer.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "complexity-guard": {
+      "prompt_path": "systemprompts/clink/complexity-guard.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "octave-specialist": {
+      "prompt_path": "systemprompts/clink/octave-specialist.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "octave-validator": {
+      "prompt_path": "systemprompts/clink/octave-validator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "semantic-optimizer": {
+      "prompt_path": "systemprompts/clink/semantic-optimizer.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "documentation-compressor": {
+      "prompt_path": "systemprompts/clink/documentation-compressor.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "compression-fidelity-validator": {
+      "prompt_path": "systemprompts/clink/compression-fidelity-validator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "hestai-doc-steward": {
+      "prompt_path": "systemprompts/clink/hestai-doc-steward.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "task-decomposer": {
+      "prompt_path": "systemprompts/clink/task-decomposer.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "task-decomposer-validator": {
+      "prompt_path": "systemprompts/clink/task-decomposer-validator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "smartsuite-expert": {
+      "prompt_path": "systemprompts/clink/smartsuite-expert.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "supabase-expert": {
+      "prompt_path": "systemprompts/clink/supabase-expert.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "skills-expert": {
+      "prompt_path": "systemprompts/clink/skills-expert.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "subagent-creator": {
+      "prompt_path": "systemprompts/clink/subagent-creator.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "solution-steward": {
+      "prompt_path": "systemprompts/clink/solution-steward.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
+    "vibe-coder": {
+      "prompt_path": "systemprompts/clink/vibe-coder.txt",
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
+    },
     "default": {
       "prompt_path": "systemprompts/clink/default.txt",
-      "role_args": []
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
     },
     "planner": {
       "prompt_path": "systemprompts/clink/default_planner.txt",
-      "role_args": []
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
     },
     "codereviewer": {
       "prompt_path": "systemprompts/clink/default_codereviewer.txt",
-      "role_args": []
+      "role_args": [
+        "--model",
+        "gemini-3-pro-preview"
+      ]
     }
-  }
+  },
+  "_generated_by": "scripts/generate_client_configs.py",
+  "_tier_mapping_version": "1.0.0"
 }


### PR DESCRIPTION
## Summary

Synchronizes clink client configuration files between agent-port and hestai-mcp-server to enable consistent CLI delegation across both projects.

## Changes

- **conf/cli_clients/claude.json**: Expanded from 3 basic roles to 50+ specialized agent roles with model-specific routing (opus/sonnet/haiku per role). Updated permission mode from `acceptEdits` to `bypassPermissions`.

- **conf/cli_clients/codex.json**: Added comprehensive role mappings for Codex CLI integration with full support for all specialized agents.

- **conf/cli_clients/gemini.json**: Added complete role configuration for Gemini provider using gemini-3-pro-preview model.

## Why This Matters

These configurations enable proper CLI delegation through clink with:
- Role-based model selection (critical decisions use opus, routine work uses haiku)
- Consistent system prompt routing across all AI providers
- Support for HestAI's multi-agent architecture through external CLI clients

## Test Plan

- [x] All three JSON files verified to match source configuration
- [x] Pre-commit checks passed
- [x] Configuration syntax validated
- [x] Files compiled: 3 modified, 939 insertions, 17 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)