### PR TITLE
feat: add MCP tool annotations to 14 tools

### DIFF
--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -140,6 +140,8 @@ class AnalyzeTool(WorkflowTool):
     including architectural review, performance analysis, security assessment, and maintainability evaluation.
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_request = None
@@ -157,7 +159,7 @@ class AnalyzeTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only analysis tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return ANALYZE_PROMPT

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -155,6 +155,10 @@ class AnalyzeTool(WorkflowTool):
             "Guides through structured code review and strategic planning."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only analysis tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         return ANALYZE_PROMPT
 

--- a/tools/apilookup.py
+++ b/tools/apilookup.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field
 
@@ -81,7 +81,7 @@ class LookupTool(SimpleTool):
             "This tool searches authoritative sources (official docs, GitHub, package registries) to ensure up-to-date accuracy."
         )
 
-    def get_annotations(self) -> Optional[dict[str, Any]]:
+    def get_annotations(self) -> dict[str, Any] | None:
         """Return tool annotations indicating this searches external sources."""
         return self._ANNOTATIONS
 

--- a/tools/apilookup.py
+++ b/tools/apilookup.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field
 
@@ -78,6 +78,10 @@ class LookupTool(SimpleTool):
             "Use this tool automatically when you need current API/SDK documentation, latest version info, breaking changes, deprecations, migration guides, or official release notes. "
             "This tool searches authoritative sources (official docs, GitHub, package registries) to ensure up-to-date accuracy."
         )
+
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this searches external sources."""
+        return {"readOnlyHint": True, "openWorldHint": True}
 
     def get_system_prompt(self) -> str:
         return ""

--- a/tools/apilookup.py
+++ b/tools/apilookup.py
@@ -70,6 +70,8 @@ SEARCH STRATEGY (MAXIMUM 2-4 SEARCHES TOTAL FOR THIS MISSION - THEN STOP):
 class LookupTool(SimpleTool):
     """Simple tool that wraps user queries with API lookup instructions."""
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True, "openWorldHint": True}
+
     def get_name(self) -> str:
         return "apilookup"
 
@@ -81,7 +83,7 @@ class LookupTool(SimpleTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this searches external sources."""
-        return {"readOnlyHint": True, "openWorldHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return ""

--- a/tools/challenge.py
+++ b/tools/challenge.py
@@ -49,6 +49,8 @@ class ChallengeTool(SimpleTool):
     transforms the input prompt into a structured critical thinking challenge.
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def get_name(self) -> str:
         return "challenge"
 
@@ -60,7 +62,7 @@ class ChallengeTool(SimpleTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only analysis tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         # Challenge tool doesn't need a system prompt since it doesn't call AI

--- a/tools/challenge.py
+++ b/tools/challenge.py
@@ -58,6 +58,10 @@ class ChallengeTool(SimpleTool):
             "Trigger automatically when a user critically questions, disagrees or appears to push back on earlier answers, and use it manually to sanity-check contentious claims."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only analysis tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         # Challenge tool doesn't need a system prompt since it doesn't call AI
         return ""

--- a/tools/codereview.py
+++ b/tools/codereview.py
@@ -140,6 +140,10 @@ class CodeReviewTool(WorkflowTool):
             "Guides through structured investigation to ensure thoroughness."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only code review tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         return CODEREVIEW_PROMPT
 

--- a/tools/codereview.py
+++ b/tools/codereview.py
@@ -125,6 +125,8 @@ class CodeReviewTool(WorkflowTool):
     including security audits, performance analysis, architectural review, and maintainability assessment.
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_request = None
@@ -142,7 +144,7 @@ class CodeReviewTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only code review tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return CODEREVIEW_PROMPT

--- a/tools/consensus.py
+++ b/tools/consensus.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field, model_validator
 
@@ -152,6 +152,10 @@ class ConsensusTool(WorkflowTool):
             "Use for complex decisions, architectural choices, feature proposals, and technology evaluations. "
             "Consults multiple models with different stances to synthesize comprehensive recommendations."
         )
+
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only consensus analysis tool."""
+        return {"readOnlyHint": True}
 
     def get_system_prompt(self) -> str:
         # For the CLI agent's initial analysis, use a neutral version of the consensus prompt

--- a/tools/consensus.py
+++ b/tools/consensus.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, model_validator
 
@@ -155,7 +155,7 @@ class ConsensusTool(WorkflowTool):
             "Consults multiple models with different stances to synthesize comprehensive recommendations."
         )
 
-    def get_annotations(self) -> Optional[dict[str, Any]]:
+    def get_annotations(self) -> dict[str, Any] | None:
         """Return tool annotations indicating this is a read-only consensus analysis tool."""
         return self._ANNOTATIONS
 

--- a/tools/consensus.py
+++ b/tools/consensus.py
@@ -135,6 +135,8 @@ class ConsensusTool(WorkflowTool):
     and finally synthesizes all perspectives into a unified recommendation.
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_prompt: str | None = None
@@ -155,7 +157,7 @@ class ConsensusTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only consensus analysis tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         # For the CLI agent's initial analysis, use a neutral version of the consensus prompt

--- a/tools/debug.py
+++ b/tools/debug.py
@@ -110,6 +110,8 @@ class DebugIssueTool(WorkflowTool):
     including race conditions, memory leaks, performance issues, and integration problems.
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_issue = None
@@ -126,7 +128,7 @@ class DebugIssueTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only debugging tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return DEBUG_ISSUE_PROMPT

--- a/tools/debug.py
+++ b/tools/debug.py
@@ -124,6 +124,10 @@ class DebugIssueTool(WorkflowTool):
             "Guides through structured investigation with hypothesis testing and expert analysis."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only debugging tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         return DEBUG_ISSUE_PROMPT
 

--- a/tools/docgen.py
+++ b/tools/docgen.py
@@ -95,6 +95,8 @@ class DocgenTool(WorkflowTool):
     - Modern documentation style appropriate for the language/platform
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_request = None
@@ -111,7 +113,7 @@ class DocgenTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only documentation tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return DOCGEN_PROMPT

--- a/tools/docgen.py
+++ b/tools/docgen.py
@@ -109,6 +109,10 @@ class DocgenTool(WorkflowTool):
             "Analyzes code structure and patterns to create thorough documentation."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only documentation tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         return DOCGEN_PROMPT
 

--- a/tools/planner.py
+++ b/tools/planner.py
@@ -119,6 +119,8 @@ class PlannerTool(WorkflowTool):
     - Self-contained operation (no expert analysis)
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.branches = {}
@@ -135,7 +137,7 @@ class PlannerTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only planning tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return PLANNER_PROMPT

--- a/tools/planner.py
+++ b/tools/planner.py
@@ -21,7 +21,7 @@ architectural decisions, and breaking down large problems into manageable steps.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field, field_validator
 
@@ -132,6 +132,10 @@ class PlannerTool(WorkflowTool):
             "Use for complex project planning, system design, migration strategies, and architectural decisions. "
             "Builds plans incrementally with deep reflection for complex scenarios."
         )
+
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only planning tool."""
+        return {"readOnlyHint": True}
 
     def get_system_prompt(self) -> str:
         return PLANNER_PROMPT

--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -126,6 +126,8 @@ class PrecommitTool(WorkflowTool):
     multi-repository analysis, security review, performance validation, and integration testing.
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_request = None
@@ -143,7 +145,7 @@ class PrecommitTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only validation tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return PRECOMMIT_PROMPT

--- a/tools/precommit.py
+++ b/tools/precommit.py
@@ -141,6 +141,10 @@ class PrecommitTool(WorkflowTool):
             "Guides through structured investigation with expert analysis."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only validation tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         return PRECOMMIT_PROMPT
 

--- a/tools/refactor.py
+++ b/tools/refactor.py
@@ -149,6 +149,8 @@ class RefactorTool(WorkflowTool):
     opportunities, and organization improvements.
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_request = None
@@ -166,7 +168,7 @@ class RefactorTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only refactoring analysis tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return REFACTOR_PROMPT

--- a/tools/refactor.py
+++ b/tools/refactor.py
@@ -164,6 +164,10 @@ class RefactorTool(WorkflowTool):
             "Guides through structured analysis with expert validation."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only refactoring analysis tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         return REFACTOR_PROMPT
 

--- a/tools/secaudit.py
+++ b/tools/secaudit.py
@@ -126,6 +126,8 @@ class SecauditTool(WorkflowTool):
     security-specific capabilities.
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_request = None
@@ -145,7 +147,7 @@ class SecauditTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only security audit tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         """Return the system prompt for expert security analysis."""

--- a/tools/secaudit.py
+++ b/tools/secaudit.py
@@ -143,6 +143,10 @@ class SecauditTool(WorkflowTool):
             "Guides through structured security investigation with expert validation."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only security audit tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         """Return the system prompt for expert security analysis."""
         return SECAUDIT_PROMPT

--- a/tools/testgen.py
+++ b/tools/testgen.py
@@ -118,6 +118,10 @@ class TestGenTool(WorkflowTool):
             "Be specific about scope - target particular components rather than testing everything."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only test generation tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         return TESTGEN_PROMPT
 

--- a/tools/testgen.py
+++ b/tools/testgen.py
@@ -103,6 +103,7 @@ class TestGenTool(WorkflowTool):
     """
 
     __test__ = False  # Prevent pytest from collecting this class as a test
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
 
     def __init__(self):
         super().__init__()
@@ -120,7 +121,7 @@ class TestGenTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only test generation tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return TESTGEN_PROMPT

--- a/tools/thinkdeep.py
+++ b/tools/thinkdeep.py
@@ -123,6 +123,10 @@ class ThinkDeepTool(WorkflowTool):
         """Return the tool description"""
         return self.description
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only deep thinking tool."""
+        return {"readOnlyHint": True}
+
     def get_model_category(self) -> "ToolModelCategory":
         """Return the model category for this tool"""
         from tools.models import ToolModelCategory

--- a/tools/thinkdeep.py
+++ b/tools/thinkdeep.py
@@ -108,6 +108,7 @@ class ThinkDeepTool(WorkflowTool):
         "Use for architecture decisions, complex bugs, performance challenges, and security analysis. "
         "Provides systematic hypothesis testing, evidence-based investigation, and expert validation."
     )
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
 
     def __init__(self):
         """Initialize the ThinkDeep workflow tool"""
@@ -125,7 +126,7 @@ class ThinkDeepTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only deep thinking tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_model_category(self) -> "ToolModelCategory":
         """Return the model category for this tool"""

--- a/tools/tracer.py
+++ b/tools/tracer.py
@@ -160,6 +160,10 @@ class TracerTool(WorkflowTool):
             "Supports precision mode (execution flow) and dependencies mode (structural relationships)."
         )
 
+    def get_annotations(self) -> Optional[dict[str, Any]]:
+        """Return tool annotations indicating this is a read-only code tracing tool."""
+        return {"readOnlyHint": True}
+
     def get_system_prompt(self) -> str:
         return TRACER_PROMPT
 

--- a/tools/tracer.py
+++ b/tools/tracer.py
@@ -145,6 +145,8 @@ class TracerTool(WorkflowTool):
     both precision tracing (execution flow) and dependencies tracing (structural relationships).
     """
 
+    _ANNOTATIONS: dict[str, Any] = {"readOnlyHint": True}
+
     def __init__(self):
         super().__init__()
         self.initial_request = None
@@ -162,7 +164,7 @@ class TracerTool(WorkflowTool):
 
     def get_annotations(self) -> Optional[dict[str, Any]]:
         """Return tool annotations indicating this is a read-only code tracing tool."""
-        return {"readOnlyHint": True}
+        return self._ANNOTATIONS
 
     def get_system_prompt(self) -> str:
         return TRACER_PROMPT


### PR DESCRIPTION
## Description

Add MCP tool annotations to 14 tools that were missing them. Tool annotations help MCP clients (like Claude) make better decisions about tool safety and behavior characteristics.

## Changes Made

- [x] Added `readOnlyHint: True` annotations to 14 analysis tools
- [x] Added `openWorldHint: True` to `apilookup` (searches external docs)
- [x] Added `Optional` import where needed (consensus.py, planner.py, apilookup.py)
- [x] No breaking changes
- [x] No new dependencies

### Tools Annotated

| Tool | Annotations | Description |
|------|-------------|-------------|
| `analyze` | `readOnlyHint: True` | Code analysis workflow |
| `apilookup` | `readOnlyHint: True`, `openWorldHint: True` | API documentation lookup |
| `challenge` | `readOnlyHint: True` | Critical thinking analysis |
| `codereview` | `readOnlyHint: True` | Code review workflow |
| `consensus` | `readOnlyHint: True` | Multi-model consensus building |
| `debug` | `readOnlyHint: True` | Debugging and root cause analysis |
| `docgen` | `readOnlyHint: True` | Documentation generation |
| `planner` | `readOnlyHint: True` | Task planning workflow |
| `precommit` | `readOnlyHint: True` | Git change validation |
| `refactor` | `readOnlyHint: True` | Refactoring analysis |
| `secaudit` | `readOnlyHint: True` | Security audit |
| `testgen` | `readOnlyHint: True` | Test generation |
| `thinkdeep` | `readOnlyHint: True` | Deep thinking analysis |
| `tracer` | `readOnlyHint: True` | Code tracing |

All these tools perform read-only analysis without modifying files, making `readOnlyHint: True` appropriate.

## Testing

- [x] Follows existing annotation pattern from `chat.py`, `version.py`, `listmodels.py`, `clink.py`
- [x] Changes are minimal (adding single method per file)
- [x] No functional changes to tool behavior

Note: This is a metadata-only change that adds hints for MCP clients. The annotation infrastructure already exists in `server.py` and is used by existing tools.

## Related Issues

N/A - Enhancement to improve MCP client integration

## Checklist

- [x] PR title follows the format guidelines above
- [x] Self-review completed
- [x] Documentation: Annotations are self-documenting via docstrings
- [x] Ready for review

## Additional Notes

This PR brings tool annotation coverage to 18/18 tools (100%), up from 4/18 (22%). Tool annotations are part of the MCP specification and help clients understand tool behavior without executing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)