### PR TITLE
fix(tool): allow additional properties in listmodels schema (fixes #376)

### DIFF
--- a/tools/listmodels.py
+++ b/tools/listmodels.py
@@ -44,7 +44,7 @@ class ListModelsTool(BaseTool):
             "type": "object",
             "properties": {},
             "required": [],
-            "additionalProperties": False,
+            "additionalProperties": True,
         }
 
     def get_annotations(self) -> Optional[dict[str, Any]]:


### PR DESCRIPTION
This PR fixes issue BeehiveInnovations/pal-mcp-server#376 where the listmodels tool would fail if the AI agent automatically injected reasoning or other metadata into the tool call. By setting additionalProperties: True, the tool now remains compatible with various AI agent implementations.