### PR TITLE
fix: Enabling `moonshotai/kimi-k2-thinking` and `z-ai/glm-4.7` (most capable open-source models as of today) for code review with PAL

### DIFF
--- a/conf/openrouter_models.json
+++ b/conf/openrouter_models.json
@@ -472,6 +472,43 @@
       "intelligence_score": 16
     },
     {
+      "model_name": "moonshotai/kimi-k2-thinking",
+      "aliases": [
+        "kimi",
+        "kimi-k2",
+        "kimi-thinking",
+        "kimi-k2-thinking"
+      ],
+      "context_window": 262144,
+      "max_output_tokens": 65536,
+      "supports_extended_thinking": false,
+      "supports_json_mode": true,
+      "supports_function_calling": true,
+      "supports_images": false,
+      "max_image_size_mb": 0.0,
+      "allow_code_generation": true,
+      "description": "MoonshotAI Kimi K2 Thinking via OpenRouter (262K context)",
+      "intelligence_score": 15
+    },
+    {
+      "model_name": "z-ai/glm-4.7",
+      "aliases": [
+        "glm",
+        "glm-4.7",
+        "glm47"
+      ],
+      "context_window": 202752,
+      "max_output_tokens": 65535,
+      "supports_extended_thinking": false,
+      "supports_json_mode": true,
+      "supports_function_calling": true,
+      "supports_images": false,
+      "max_image_size_mb": 0.0,
+      "allow_code_generation": true,
+      "description": "Z.AI GLM 4.7 via OpenRouter (202,752 context)",
+      "intelligence_score": 13
+    },
+    {
       "model_name": "x-ai/grok-4",
       "aliases": [
         "grok-4",

--- a/conf/openrouter_models.json
+++ b/conf/openrouter_models.json
@@ -498,7 +498,7 @@
         "glm47"
       ],
       "context_window": 202752,
-      "max_output_tokens": 65535,
+      "max_output_tokens": 65536,
       "supports_extended_thinking": false,
       "supports_json_mode": true,
       "supports_function_calling": true,

--- a/conf/openrouter_models.json
+++ b/conf/openrouter_models.json
@@ -487,7 +487,7 @@
       "supports_images": false,
       "max_image_size_mb": 0.0,
       "allow_code_generation": true,
-      "description": "MoonshotAI Kimi K2 Thinking via OpenRouter (262K context)",
+      "description": "MoonshotAI Kimi K2 Thinking via OpenRouter (262,144 context)",
       "intelligence_score": 15
     },
     {


### PR DESCRIPTION
## Description

Enabling `moonshotai/kimi-k2-thinking` and `z-ai/glm-4.7` (most capable open-source models as of today) for code review with PAL.

Added them to the OpenRouter configuration to allow proper context. Without this fix, PAL thinks their context window is 32k, rendering these most powerful open-source models virtually unusable for code review tasks.

## Changes Made

- Added `moonshotai/kimi-k2-thinking` with the proper context window configuration to `conf/openrouter_models.json`.
- Added `z-ai/glm-4.7` with the proper context window configuration to `conf/openrouter_models.json`.

## Testing

**Please review our [Testing Guide](../docs/testing.md) before submitting.**

### Run all linting and tests (required):

- [x] All linting passes (ruff, black, isort)
- [x] All unit tests pass
- [ ] **For new features**: Unit tests added in `tests/`
- [ ] **For tool changes**: Simulator tests added in `simulator_tests/`
- [ ] **For bug fixes**: Tests added to prevent regression
- [ ] Simulator tests pass (if applicable)
- [x] Manual testing completed with realistic scenarios

## Related Issues

Fixes #(issue number)

## Checklist

- [x] PR title follows the format guidelines above
- [x] **Activated venv and ran code quality checks: `source venv/bin/activate && ./code_quality_checks.sh`**
- [x] Self-review completed
- [ ] **Tests added for ALL changes** (see Testing section above)
- [ ] Documentation updated as needed
- [x] All unit tests passing
- [ ] Relevant simulator tests passing (if tool changes)
- [x] Ready for review