### PR TITLE
feat(clink): add Qwen CLI support

### DIFF
--- a/clink/agents/__init__.py
+++ b/clink/agents/__init__.py
@@ -8,11 +8,13 @@ from .base import AgentOutput, BaseCLIAgent, CLIAgentError
 from .claude import ClaudeAgent
 from .codex import CodexAgent
 from .gemini import GeminiAgent
+from .qwen import QwenAgent
 
 _AGENTS: dict[str, type[BaseCLIAgent]] = {
     "gemini": GeminiAgent,
     "codex": CodexAgent,
     "claude": ClaudeAgent,
+    "qwen": QwenAgent,
 }
 
 

--- a/clink/agents/qwen.py
+++ b/clink/agents/qwen.py
@@ -1,0 +1,88 @@
+"""Qwen-specific CLI agent hooks."""
+
+from __future__ import annotations
+
+import json
+
+from clink.models import ResolvedCLIClient
+from clink.parsers.base import ParsedCLIResponse
+
+from .base import AgentOutput, BaseCLIAgent
+
+
+class QwenAgent(BaseCLIAgent):
+    """Qwen-specific behaviour."""
+
+    def __init__(self, client: ResolvedCLIClient):
+        super().__init__(client)
+
+    def _recover_from_error(
+        self,
+        *,
+        returncode: int,
+        stdout: str,
+        stderr: str,
+        sanitized_command: list[str],
+        duration_seconds: float,
+        output_file_content: str | None,
+    ) -> AgentOutput | None:
+        combined = "\n".join(part for part in (stderr, stdout) if part)
+        if not combined:
+            return None
+
+        brace_index = combined.find("{")
+        if brace_index == -1:
+            return None
+
+        json_candidate = combined[brace_index:]
+        try:
+            payload, _ = json.JSONDecoder().raw_decode(json_candidate)
+        except json.JSONDecodeError:
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+
+        error_block = payload.get("error")
+        if not isinstance(error_block, dict):
+            return None
+
+        code = error_block.get("code")
+        err_type = error_block.get("type")
+        detail_message = error_block.get("message")
+
+        prologue = combined[:brace_index].strip()
+        lines: list[str] = []
+        if prologue and (not detail_message or prologue not in detail_message):
+            lines.append(prologue)
+        if detail_message:
+            lines.append(detail_message)
+
+        header = "Qwen CLI reported a tool failure"
+        if code:
+            header = f"{header} ({code})"
+        elif err_type:
+            header = f"{header} ({err_type})"
+
+        content_lines = [header.rstrip(".") + "."]
+        content_lines.extend(lines)
+        message = "\n".join(content_lines).strip()
+
+        metadata = {
+            "cli_error_recovered": True,
+            "cli_error_code": code,
+            "cli_error_type": err_type,
+            "cli_error_payload": payload,
+        }
+
+        parsed = ParsedCLIResponse(content=message or header, metadata=metadata)
+        return AgentOutput(
+            parsed=parsed,
+            sanitized_command=sanitized_command,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+            duration_seconds=duration_seconds,
+            parser_name=self._parser.name,
+            output_file_content=output_file_content,
+        )

--- a/clink/constants.py
+++ b/clink/constants.py
@@ -39,6 +39,12 @@ INTERNAL_DEFAULTS: dict[str, CLIInternalDefaults] = {
         default_role_prompt="systemprompts/clink/default.txt",
         runner="codex",
     ),
+    "qwen": CLIInternalDefaults(
+        parser="claude_json",
+        additional_args=["-o", "json"],
+        default_role_prompt="systemprompts/clink/default.txt",
+        runner="qwen",
+    ),
     "claude": CLIInternalDefaults(
         parser="claude_json",
         additional_args=["--print", "--output-format", "json"],

--- a/conf/cli_clients/qwen.json
+++ b/conf/cli_clients/qwen.json
@@ -1,0 +1,22 @@
+{
+  "name": "qwen",
+  "command": "qwen",
+  "additional_args": [
+    "--yolo"
+  ],
+  "env": {},
+  "roles": {
+    "default": {
+      "prompt_path": "systemprompts/clink/default.txt",
+      "role_args": []
+    },
+    "planner": {
+      "prompt_path": "systemprompts/clink/default_planner.txt",
+      "role_args": []
+    },
+    "codereviewer": {
+      "prompt_path": "systemprompts/clink/default_codereviewer.txt",
+      "role_args": []
+    }
+  }
+}

--- a/simulator_tests/test_chat_simple_validation.py
+++ b/simulator_tests/test_chat_simple_validation.py
@@ -13,7 +13,6 @@ Comprehensive test for the new ChatSimple tool implementation that validates:
 - Conversation context preservation across turns
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_conversation_chain_validation.py
+++ b/simulator_tests/test_conversation_chain_validation.py
@@ -21,7 +21,6 @@ This validates the conversation threading system's ability to:
 - Properly traverse parent relationships for history reconstruction
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_cross_tool_comprehensive.py
+++ b/simulator_tests/test_cross_tool_comprehensive.py
@@ -12,7 +12,6 @@ Validates:
 5. Proper tool chaining with context
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_ollama_custom_url.py
+++ b/simulator_tests/test_ollama_custom_url.py
@@ -9,7 +9,6 @@ Tests custom API endpoint functionality with Ollama-style local models, includin
 - Model alias resolution for local models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_fallback.py
+++ b/simulator_tests/test_openrouter_fallback.py
@@ -8,7 +8,6 @@ Tests that verify the system correctly falls back to OpenRouter when:
 - Auto mode correctly selects OpenRouter models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_models.py
+++ b/simulator_tests/test_openrouter_models.py
@@ -9,7 +9,6 @@ Tests that verify OpenRouter functionality including:
 - Error handling when models are not available
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_xai_models.py
+++ b/simulator_tests/test_xai_models.py
@@ -9,7 +9,6 @@ Tests that verify X.AI GROK functionality including:
 - API integration and response validation
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/tests/test_directory_expansion_tracking.py
+++ b/tests/test_directory_expansion_tracking.py
@@ -37,8 +37,7 @@ class TestDirectoryExpansionTracking:
         files = []
         for i in range(5):
             swift_file = temp_path / f"File{i}.swift"
-            swift_file.write_text(
-                f"""
+            swift_file.write_text(f"""
 import Foundation
 
 class TestClass{i} {{
@@ -46,18 +45,15 @@ class TestClass{i} {{
         return "test{i}"
     }}
 }}
-"""
-            )
+""")
             files.append(str(swift_file))
 
         # Create a Python file as well
         python_file = temp_path / "helper.py"
-        python_file.write_text(
-            """
+        python_file.write_text("""
 def helper_function():
     return "helper"
-"""
-        )
+""")
         files.append(str(python_file))
 
         try:

--- a/tests/test_docker_implementation.py
+++ b/tests/test_docker_implementation.py
@@ -310,13 +310,11 @@ def temp_project_dir():
 
         # Create base files
         (temp_path / "server.py").write_text("# Mock server.py")
-        (temp_path / "Dockerfile").write_text(
-            """
+        (temp_path / "Dockerfile").write_text("""
 FROM python:3.11-slim
 COPY server.py /app/
 CMD ["python", "/app/server.py"]
-"""
-        )
+""")
 
         yield temp_path
 

--- a/tests/test_prompt_regression.py
+++ b/tests/test_prompt_regression.py
@@ -86,16 +86,14 @@ class TestPromptIntegration:
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def hello_world():
     \"\"\"A simple hello world function.\"\"\"
     return "Hello, World!"
 
 if __name__ == "__main__":
     print(hello_world())
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -155,8 +153,7 @@ if __name__ == "__main__":
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def process_user_input(user_input):
     # Potentially unsafe code for demonstration
     query = f"SELECT * FROM users WHERE name = '{user_input}'"
@@ -166,8 +163,7 @@ def main():
     user_name = input("Enter name: ")
     result = process_user_input(user_name)
     print(result)
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -241,8 +237,7 @@ def main():
 
         # Create a temporary Python file demonstrating MVC pattern
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 # Model
 class User:
     def __init__(self, name, email):
@@ -262,8 +257,7 @@ class UserController:
 
     def get_user_display(self):
         return self.view.display_user(self.model)
-"""
-            )
+""")
             temp_file = f.name
 
         try:


### PR DESCRIPTION
## Summary
- Adds Qwen CLI as a new clink client
- Uses `claude_json` parser (Qwen's `-o json` output matches Claude CLI's JSON array format)
- Includes JSON error recovery agent modeled after Gemini's pattern
- Reuses existing default system prompts and role configurations

## Test plan
- [x] All 20 clink unit tests pass
- [x] Linting clean (ruff, black, isort)
- [x] Manual end-to-end test with `cli_name=qwen` confirmed working