### PR TITLE
Improve consensus model routing and upgrade thinkdeep with deepthink-style strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,6 +216,12 @@ DISABLED_TOOLS=analyze,refactor,testgen,secaudit,docgen,tracer
 #   CI/CD environments: false (respects pipeline secrets)
 PAL_MCP_FORCE_ENV_OVERRIDE=false
 
+# Optional: Mirror server logs to stderr (NOT recommended for most MCP clients).
+# Some MCP clients do not drain stderr; verbose logging can fill the stderr pipe
+# buffer and deadlock the server, which appears as the client "stuck" on tool calls.
+# Logs are always written to logs/mcp_server.log regardless.
+# PAL_MCP_LOG_TO_STDERR=false
+
 # ===========================================
 # Docker Configuration
 # ===========================================

--- a/conf/zai_models.json
+++ b/conf/zai_models.json
@@ -17,7 +17,7 @@
         "zai",
         "glm47"
       ],
-      "intelligence_score": 16,
+      "intelligence_score": 18,
       "description": "Z.ai flagship GLM-4.7 (OpenAI-compatible)",
       "context_window": 200000,
       "max_output_tokens": 128000,
@@ -52,7 +52,6 @@
       "model_name": "glm-4.7-flash",
       "friendly_name": "Z.ai (GLM-4.7-Flash)",
       "aliases": [
-        "flash",
         "glm47-flash"
       ],
       "intelligence_score": 12,
@@ -69,4 +68,3 @@
     }
   ]
 }
-

--- a/conf/zai_models.json
+++ b/conf/zai_models.json
@@ -1,0 +1,72 @@
+{
+  "_README": {
+    "description": "Model metadata for Z.ai when used via the Custom (OpenAI-compatible) provider.",
+    "usage": "Use this manifest when you want to restrict Z.ai usage to the GLM-4.7 family only.",
+    "example_env": [
+      "CUSTOM_API_URL=https://api.z.ai/api/paas/v4/",
+      "CUSTOM_API_KEY=your_zai_api_key_here",
+      "CUSTOM_MODELS_CONFIG_PATH=/absolute/path/to/conf/zai_models.json",
+      "CUSTOM_ALLOWED_MODELS=glm-4.7,glm-4.7-flash,glm-4.7-flashx"
+    ]
+  },
+  "models": [
+    {
+      "model_name": "glm-4.7",
+      "friendly_name": "Z.ai (GLM-4.7)",
+      "aliases": [
+        "zai",
+        "glm47"
+      ],
+      "intelligence_score": 16,
+      "description": "Z.ai flagship GLM-4.7 (OpenAI-compatible)",
+      "context_window": 200000,
+      "max_output_tokens": 128000,
+      "supports_extended_thinking": false,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true
+    },
+    {
+      "model_name": "glm-4.7-flashx",
+      "friendly_name": "Z.ai (GLM-4.7-FlashX)",
+      "aliases": [
+        "flashx",
+        "glm47-flashx"
+      ],
+      "intelligence_score": 13,
+      "description": "Z.ai GLM-4.7-FlashX (OpenAI-compatible)",
+      "context_window": 200000,
+      "max_output_tokens": 128000,
+      "supports_extended_thinking": false,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true
+    },
+    {
+      "model_name": "glm-4.7-flash",
+      "friendly_name": "Z.ai (GLM-4.7-Flash)",
+      "aliases": [
+        "flash",
+        "glm47-flash"
+      ],
+      "intelligence_score": 12,
+      "description": "Z.ai GLM-4.7-Flash (OpenAI-compatible)",
+      "context_window": 200000,
+      "max_output_tokens": 128000,
+      "supports_extended_thinking": false,
+      "supports_system_prompts": true,
+      "supports_streaming": true,
+      "supports_function_calling": true,
+      "supports_json_mode": true,
+      "supports_images": false,
+      "supports_temperature": true
+    }
+  ]
+}
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,18 @@ DEFAULT_MODEL=auto  # Claude picks best model for each task (recommended)
 
   > **Tip:** Copy the JSON file you need, customise it, and point the corresponding `*_MODELS_CONFIG_PATH` environment variable to your version. This lets you enable or disable capabilities (JSON mode, function calling, temperature support, code generation) without editing Python.
 
+### MCP Client “Stuck” / Hanging Fix (stderr logging)
+
+Some MCP clients only read stdout for JSON-RPC and do not drain stderr. If the server writes verbose logs to stderr, the stderr pipe buffer can fill and the server can block on logging, which looks like tool calls are stuck.
+
+PAL logs to `logs/mcp_server.log` by default. To **also** mirror logs to stderr, explicitly opt in:
+
+```env
+PAL_MCP_LOG_TO_STDERR=true
+```
+
+If you see hangs in your client, ensure `PAL_MCP_LOG_TO_STDERR` is unset or `false`.
+
 ### Code Generation Capability
 
 **`allow_code_generation` Flag:**

--- a/docs/custom_models.md
+++ b/docs/custom_models.md
@@ -46,6 +46,8 @@ PAL ships multiple registries:
 
 Copy whichever file you need into your project (or point the corresponding `*_MODELS_CONFIG_PATH` env var at your own copy) and edit it to advertise the models you want.
 
+When using consensus across multiple providers, avoid ambiguous aliases that overlap with native providers (for example `flash`). Prefer explicit canonical names like `glm-4.7-flash` and `gemini-2.5-flash`.
+
 ### OpenRouter Models (Cloud)
 
 The curated defaults in `conf/openrouter_models.json` include popular entries such as:
@@ -199,6 +201,12 @@ CUSTOM_MODEL_NAME=your-loaded-model
 # Local models (with custom URL configured):
 "Use local-llama to analyze this code"     # → llama3.2 (local)
 "Use local to debug this function"         # → llama3.2 (local)
+```
+
+**Z.ai / GLM example (Custom provider):**
+```
+"Use glm-4.7 via pal consensus to review this architecture"
+"Use glm-4.7-flashx for a faster second opinion"
 ```
 
 **Using full model names:**

--- a/docs/tools/consensus.md
+++ b/docs/tools/consensus.md
@@ -83,11 +83,21 @@ Get a consensus from gemini supporting the idea for implementing X, grok opposin
 
 ## Model Configuration Examples
 
+**Important:** When multiple providers define the same alias (for example `flash`), consensus requires explicit canonical model names to avoid ambiguous routing.
+
 **Basic For/Against:**
 ```json
 [
-    {"model": "flash", "stance": "for"},
+    {"model": "gemini-2.5-flash", "stance": "for"},
     {"model": "pro", "stance": "against"}
+]
+```
+
+**GLM Default Inclusion Example:**
+```json
+[
+    {"model": "glm-4.7", "stance": "neutral"},
+    {"model": "gpt-5.2", "stance": "against"}
 ]
 ```
 

--- a/docs/tools/thinkdeep.md
+++ b/docs/tools/thinkdeep.md
@@ -26,6 +26,7 @@ with the best architecture for my project
 - **Image support**: Analyze architectural diagrams, flowcharts, design mockups: `"Think deeper about this system architecture diagram with gemini pro using max thinking mode"`
 - **Enhanced Critical Evaluation (v2.10.0)**: After Gemini's analysis, Claude is prompted to critically evaluate the suggestions, consider context and constraints, identify risks, and synthesize a final recommendation - ensuring a balanced, well-considered solution
 - **Web search capability**: Automatically identifies areas where current documentation or community solutions would strengthen the analysis and instructs Claude to perform targeted searches
+- **DeepThink-style reasoning (new)**: Builds a task-specific reasoning structure (SELF-DISCOVER inspired) and emits uncertainty-routing metadata (`majority_vote` vs `greedy`) to guide convergence strategy
 
 ## Tool Parameters
 
@@ -38,6 +39,10 @@ with the best architecture for my project
 - `temperature`: Temperature for creative thinking (0-1, default 0.7)
 - `thinking_mode`: minimal|low|medium|high|max (default: high, Gemini only)
 - `continuation_id`: Continue previous conversations
+- `deepthink_samples`: Number of sampled reasoning paths used for uncertainty-routing metadata (1-10, default: 3)
+- `confidence_threshold`: Threshold used for routing decision (0-1, default: 0.7)
+- `enable_self_discover`: Enable task-specific reasoning module planning (default: true)
+- `reasoning_modules_limit`: Maximum modules in generated reasoning plan (3-15, default: 7)
 
 ## Usage Examples
 

--- a/systemprompts/thinkdeep_prompt.py
+++ b/systemprompts/thinkdeep_prompt.py
@@ -43,6 +43,12 @@ KEY FOCUS AREAS (apply when relevant)
 - Quality & Maintainability: readability, testing, monitoring, refactoring
 - Integration & Deployment: ONLY IF APPLICABLE TO THE QUESTION - external systems, compatibility, configuration, operational concerns
 
+DEEPTHINK MODE
+When the context includes a reasoning structure or uncertainty-routing metadata:
+- Follow the provided reasoning structure explicitly and keep steps traceable.
+- If confidence is low, broaden alternatives and identify missing evidence.
+- If confidence is high, converge on the best-supported recommendation with clear tradeoffs.
+
 EVALUATION
 Your response will be reviewed by the agent before any decision is made. Your goal is to practically extend the agent's thinking,
 surface blind spots, and refine options—not to deliver final answers in isolation.

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -105,6 +105,32 @@ class TestConsensusTool:
                 continuation_id="test-id",
             )
 
+    def test_rejects_ambiguous_model_aliases(self, monkeypatch):
+        """Consensus should reject ambiguous aliases and require canonical names."""
+        tool = ConsensusTool()
+
+        def fake_candidates(model_name):
+            if model_name == "flash":
+                return ["gemini-2.5-flash", "glm-4.7-flash"]
+            return [model_name]
+
+        monkeypatch.setattr(tool, "_get_model_resolution_candidates", fake_candidates)
+
+        with pytest.raises(ValueError, match="Ambiguous model alias 'flash'"):
+            tool._validate_model_alias_ambiguity(
+                [{"model": "flash", "stance": "neutral"}, {"model": "o3-mini", "stance": "for"}]
+            )
+
+    def test_accepts_canonical_glm_model(self, monkeypatch):
+        """Canonical GLM model names should pass ambiguity checks."""
+        tool = ConsensusTool()
+
+        monkeypatch.setattr(tool, "_get_model_resolution_candidates", lambda model_name: [model_name])
+
+        tool._validate_model_alias_ambiguity(
+            [{"model": "glm-4.7", "stance": "neutral"}, {"model": "o3-mini", "stance": "for"}]
+        )
+
     def test_input_schema_generation(self):
         """Test that input schema is generated correctly."""
         tool = ConsensusTool()

--- a/tests/test_consensus_schema.py
+++ b/tests/test_consensus_schema.py
@@ -16,9 +16,18 @@ def test_consensus_models_field_includes_available_models(monkeypatch):
         MethodType(lambda self, limit=5: (["gemini-2.5-pro (score 100, 1.0M ctx, thinking)"], 1, False), tool),
     )
     monkeypatch.setattr(tool, "_get_restriction_note", MethodType(lambda self: None, tool))
+    monkeypatch.setattr(
+        tool,
+        "_get_glm_default_hint",
+        MethodType(
+            lambda self: "Default consensus roster guidance: when the user does not specify models, include `glm-4.7` as one of the consulted models.",
+            tool,
+        ),
+    )
 
     schema = tool.get_input_schema()
     models_field_description = schema["properties"]["models"]["description"]
 
     assert "listmodels" in models_field_description
     assert "Top models" in models_field_description
+    assert "glm-4.7" in models_field_description

--- a/tests/test_thinkdeep_deepthink.py
+++ b/tests/test_thinkdeep_deepthink.py
@@ -1,0 +1,63 @@
+"""DeepThink-inspired behavior tests for ThinkDeepTool."""
+
+from tools.thinkdeep import ThinkDeepTool, ThinkDeepWorkflowRequest
+
+
+def _make_request(**overrides):
+    payload = {
+        "step": "Analyze authentication architecture and performance tradeoffs",
+        "step_number": 1,
+        "total_steps": 2,
+        "next_step_required": True,
+        "findings": "Initial findings: session handling and token validation paths need comparison.",
+        "confidence": "medium",
+        "focus_areas": ["architecture", "security", "performance"],
+    }
+    payload.update(overrides)
+    return ThinkDeepWorkflowRequest(**payload)
+
+
+def test_thinkdeep_schema_exposes_deepthink_fields():
+    tool = ThinkDeepTool()
+    schema = tool.get_input_schema()
+    properties = schema["properties"]
+
+    assert "deepthink_samples" in properties
+    assert "confidence_threshold" in properties
+    assert "enable_self_discover" in properties
+    assert "reasoning_modules_limit" in properties
+
+
+def test_build_deepthink_strategy_includes_reasoning_structure():
+    tool = ThinkDeepTool()
+    request = _make_request(enable_self_discover=True, reasoning_modules_limit=5)
+
+    strategy = tool._build_deepthink_strategy(request)
+
+    assert strategy["enable_self_discover"] is True
+    assert strategy["reasoning_structure"] is not None
+    assert len(strategy["selected_modules"]) >= 1
+    assert len(strategy["selected_modules"]) <= 5
+    assert strategy["uncertainty_routing"]["routing_decision"] in {"majority_vote", "greedy"}
+
+
+def test_uncertainty_routing_prefers_majority_vote_for_high_confidence():
+    tool = ThinkDeepTool()
+    request = _make_request(confidence="very_high", confidence_threshold=0.7, deepthink_samples=4)
+
+    strategy = tool._build_deepthink_strategy(request)
+    routing = strategy["uncertainty_routing"]
+
+    assert routing["routing_decision"] == "majority_vote"
+    assert routing["confidence_score"] >= 0.7
+
+
+def test_uncertainty_routing_prefers_greedy_for_low_confidence():
+    tool = ThinkDeepTool()
+    request = _make_request(confidence="exploring", confidence_threshold=0.8, deepthink_samples=3)
+
+    strategy = tool._build_deepthink_strategy(request)
+    routing = strategy["uncertainty_routing"]
+
+    assert routing["routing_decision"] == "greedy"
+    assert routing["confidence_score"] < 0.8


### PR DESCRIPTION
## Summary
- enforce explicit model routing in `consensus` by rejecting ambiguous aliases
- surface GLM default guidance and tune Z.ai model metadata/aliases
- redesign `thinkdeep` with deepthink-inspired reasoning modules plus uncertainty routing metadata
- update docs for `consensus`, `custom_models`, and `thinkdeep`
- add focused tests for consensus ambiguity/GLM guidance and thinkdeep deepthink behavior

## Validation
- `source .pal_venv/bin/activate && pytest tests/test_consensus.py tests/test_consensus_schema.py -q`
- `source .pal_venv/bin/activate && pytest tests/test_thinkdeep_deepthink.py tests/test_tools.py::TestThinkDeepTool::test_tool_metadata -q`
- `source .pal_venv/bin/activate && python communication_simulator_test.py --individual consensus_workflow_accurate --verbose`
- `source .pal_venv/bin/activate && python communication_simulator_test.py --individual thinkdeep_validation --verbose`
