### PR TITLE
fix: skip API key requirement when only non-LLM tools are enabled

### DIFF
--- a/server.py
+++ b/server.py
@@ -541,8 +541,7 @@ def configure_providers():
         logger.info(f"Registered providers: {', '.join(registered_providers)}")
 
     # Check if any enabled tools require LLM providers
-    NON_LLM_TOOLS = {"clink", "version", "listmodels", "challenge", "apilookup"}
-    llm_tools_active = set(TOOLS.keys()) - NON_LLM_TOOLS
+    llm_tools_active = {name for name, tool in TOOLS.items() if tool.requires_model()}
 
     # Require at least one valid provider only if LLM tools are enabled
     if not valid_providers and llm_tools_active:
@@ -556,7 +555,10 @@ def configure_providers():
             "- CUSTOM_API_URL for local models (Ollama, vLLM, etc.)"
         )
     elif not valid_providers:
-        logger.warning("No API providers configured. Only non-LLM tools (clink, version, etc.) will be available.")
+        non_llm_names = sorted(set(TOOLS.keys()) - llm_tools_active)
+        logger.warning(
+            f"No API providers configured. Only non-LLM tools ({', '.join(non_llm_names)}) will be available."
+        )
 
     logger.info(f"Available providers: {', '.join(valid_providers)}")
 

--- a/server.py
+++ b/server.py
@@ -540,8 +540,12 @@ def configure_providers():
     if registered_providers:
         logger.info(f"Registered providers: {', '.join(registered_providers)}")
 
-    # Require at least one valid provider
-    if not valid_providers:
+    # Check if any enabled tools require LLM providers
+    NON_LLM_TOOLS = {"clink", "version", "listmodels", "challenge", "apilookup"}
+    llm_tools_active = set(TOOLS.keys()) - NON_LLM_TOOLS
+
+    # Require at least one valid provider only if LLM tools are enabled
+    if not valid_providers and llm_tools_active:
         raise ValueError(
             "At least one API configuration is required. Please set either:\n"
             "- GEMINI_API_KEY for Gemini models\n"
@@ -551,6 +555,8 @@ def configure_providers():
             "- OPENROUTER_API_KEY for OpenRouter (multiple models)\n"
             "- CUSTOM_API_URL for local models (Ollama, vLLM, etc.)"
         )
+    elif not valid_providers:
+        logger.warning("No API providers configured. Only non-LLM tools (clink, version, etc.) will be available.")
 
     logger.info(f"Available providers: {', '.join(valid_providers)}")
 
@@ -614,7 +620,7 @@ def configure_providers():
     # Check if auto mode has any models available after restrictions
     from config import IS_AUTO_MODE
 
-    if IS_AUTO_MODE:
+    if IS_AUTO_MODE and llm_tools_active:
         available_models = ModelProviderRegistry.get_available_models(respect_restrictions=True)
         if not available_models:
             logger.error(
@@ -625,6 +631,8 @@ def configure_providers():
                 "No models available for auto mode due to restrictions. "
                 "Please adjust your allowed model settings or disable auto mode."
             )
+    elif IS_AUTO_MODE and not llm_tools_active:
+        logger.info("Auto mode skipped - no LLM tools are active.")
 
 
 @server.list_tools()

--- a/simulator_tests/test_chat_simple_validation.py
+++ b/simulator_tests/test_chat_simple_validation.py
@@ -13,7 +13,6 @@ Comprehensive test for the new ChatSimple tool implementation that validates:
 - Conversation context preservation across turns
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_conversation_chain_validation.py
+++ b/simulator_tests/test_conversation_chain_validation.py
@@ -21,7 +21,6 @@ This validates the conversation threading system's ability to:
 - Properly traverse parent relationships for history reconstruction
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_cross_tool_comprehensive.py
+++ b/simulator_tests/test_cross_tool_comprehensive.py
@@ -12,7 +12,6 @@ Validates:
 5. Proper tool chaining with context
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_ollama_custom_url.py
+++ b/simulator_tests/test_ollama_custom_url.py
@@ -9,7 +9,6 @@ Tests custom API endpoint functionality with Ollama-style local models, includin
 - Model alias resolution for local models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_fallback.py
+++ b/simulator_tests/test_openrouter_fallback.py
@@ -8,7 +8,6 @@ Tests that verify the system correctly falls back to OpenRouter when:
 - Auto mode correctly selects OpenRouter models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_models.py
+++ b/simulator_tests/test_openrouter_models.py
@@ -9,7 +9,6 @@ Tests that verify OpenRouter functionality including:
 - Error handling when models are not available
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_xai_models.py
+++ b/simulator_tests/test_xai_models.py
@@ -9,7 +9,6 @@ Tests that verify X.AI GROK functionality including:
 - API integration and response validation
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/tests/test_directory_expansion_tracking.py
+++ b/tests/test_directory_expansion_tracking.py
@@ -37,8 +37,7 @@ class TestDirectoryExpansionTracking:
         files = []
         for i in range(5):
             swift_file = temp_path / f"File{i}.swift"
-            swift_file.write_text(
-                f"""
+            swift_file.write_text(f"""
 import Foundation
 
 class TestClass{i} {{
@@ -46,18 +45,15 @@ class TestClass{i} {{
         return "test{i}"
     }}
 }}
-"""
-            )
+""")
             files.append(str(swift_file))
 
         # Create a Python file as well
         python_file = temp_path / "helper.py"
-        python_file.write_text(
-            """
+        python_file.write_text("""
 def helper_function():
     return "helper"
-"""
-        )
+""")
         files.append(str(python_file))
 
         try:

--- a/tests/test_docker_implementation.py
+++ b/tests/test_docker_implementation.py
@@ -310,13 +310,11 @@ def temp_project_dir():
 
         # Create base files
         (temp_path / "server.py").write_text("# Mock server.py")
-        (temp_path / "Dockerfile").write_text(
-            """
+        (temp_path / "Dockerfile").write_text("""
 FROM python:3.11-slim
 COPY server.py /app/
 CMD ["python", "/app/server.py"]
-"""
-        )
+""")
 
         yield temp_path
 

--- a/tests/test_prompt_regression.py
+++ b/tests/test_prompt_regression.py
@@ -86,16 +86,14 @@ class TestPromptIntegration:
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def hello_world():
     \"\"\"A simple hello world function.\"\"\"
     return "Hello, World!"
 
 if __name__ == "__main__":
     print(hello_world())
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -155,8 +153,7 @@ if __name__ == "__main__":
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def process_user_input(user_input):
     # Potentially unsafe code for demonstration
     query = f"SELECT * FROM users WHERE name = '{user_input}'"
@@ -166,8 +163,7 @@ def main():
     user_name = input("Enter name: ")
     result = process_user_input(user_name)
     print(result)
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -241,8 +237,7 @@ def main():
 
         # Create a temporary Python file demonstrating MVC pattern
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 # Model
 class User:
     def __init__(self, name, email):
@@ -262,8 +257,7 @@ class UserController:
 
     def get_user_display(self):
         return self.view.display_user(self.model)
-"""
-            )
+""")
             temp_file = f.name
 
         try:


### PR DESCRIPTION
## Summary

- When all LLM-requiring tools are disabled via `DISABLED_TOOLS`, the server now starts without requiring any API keys
- Non-LLM tools (`clink`, `version`, `listmodels`, `challenge`, `apilookup`) work independently of provider configuration
- Auto-mode validation is also skipped when no LLM tools are active
- Addresses Issue #402 
## Problem

If you only need `clink` to bridge requests to external CLI programs, you still had to configure a valid API key or the server would crash on startup with:

```
ValueError: At least one API configuration is required.
```

This forced users to obtain and configure API keys they don't need.

## Changes

- `server.py`: Made the provider requirement check conditional — only enforced when LLM tools are in the active tool set
- `server.py`: Made the auto-mode model availability check conditional on LLM tools being active
- Added warning log when no providers are configured (instead of crashing)

## Test plan

- [x] Verified server starts with `DISABLED_TOOLS=analyze,refactor,testgen,secaudit,docgen,tracer,chat,thinkdeep,planner,consensus,codereview,precommit,debug` and placeholder API keys
- [x] Server logs `WARNING - No API providers configured. Only non-LLM tools (clink, version, etc.) will be available.`
- [x] Server reaches `Server ready - waiting for tool requests...`
- [x] Existing behavior unchanged when LLM tools are enabled with valid keys