### PR TITLE
fix(security): disable filesystem edits by default for clink CLI

### DIFF
--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -68,7 +68,7 @@ class BaseCLIAgent:
         _ = (files, images)
         # The runner simply executes the configured CLI command for the selected role.
         command = self._build_command(
-            role=role, 
+            role=role,
             system_prompt=system_prompt,
             allow_edits=allow_edits,
             editable_paths=editable_paths,
@@ -198,9 +198,9 @@ class BaseCLIAgent:
         )
 
     def _build_command(
-        self, 
-        *, 
-        role: ResolvedCLIRole, 
+        self,
+        *,
+        role: ResolvedCLIRole,
         system_prompt: str | None,
         allow_edits: bool = False,
         editable_paths: Sequence[str] = (),

--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -60,12 +60,19 @@ class BaseCLIAgent:
         system_prompt: str | None = None,
         files: Sequence[str],
         images: Sequence[str],
+        allow_edits: bool = False,
+        editable_paths: Sequence[str] = (),
     ) -> AgentOutput:
         # Files and images are already embedded into the prompt by the tool; they are
         # accepted here only to keep parity with SimpleTool callers.
         _ = (files, images)
         # The runner simply executes the configured CLI command for the selected role.
-        command = self._build_command(role=role, system_prompt=system_prompt)
+        command = self._build_command(
+            role=role, 
+            system_prompt=system_prompt,
+            allow_edits=allow_edits,
+            editable_paths=editable_paths,
+        )
         env = self._build_environment()
 
         # Resolve executable path for cross-platform compatibility (especially Windows)
@@ -190,7 +197,14 @@ class BaseCLIAgent:
             output_file_content=output_file_content,
         )
 
-    def _build_command(self, *, role: ResolvedCLIRole, system_prompt: str | None) -> list[str]:
+    def _build_command(
+        self, 
+        *, 
+        role: ResolvedCLIRole, 
+        system_prompt: str | None,
+        allow_edits: bool = False,
+        editable_paths: Sequence[str] = (),
+    ) -> list[str]:
         base = list(self.client.executable)
         base.extend(self.client.internal_args)
         base.extend(self.client.config_args)

--- a/clink/agents/claude.py
+++ b/clink/agents/claude.py
@@ -8,6 +8,7 @@ from clink.parsers.base import ParserError
 from .base import AgentOutput, BaseCLIAgent
 from collections.abc import Sequence
 
+
 class ClaudeAgent(BaseCLIAgent):
     """Claude CLI agent with system-prompt injection support."""
 
@@ -84,9 +85,11 @@ class ClaudeAgent(BaseCLIAgent):
                 sanitized.append(arg)
 
         if not found:
-            sanitized.extend([
-                "--permission-mode",
-                "acceptEdits" if allow_edits else "default",
-            ])
+            sanitized.extend(
+                [
+                    "--permission-mode",
+                    "acceptEdits" if allow_edits else "default",
+                ]
+            )
 
         return sanitized

--- a/clink/agents/claude.py
+++ b/clink/agents/claude.py
@@ -6,18 +6,35 @@ from clink.models import ResolvedCLIRole
 from clink.parsers.base import ParserError
 
 from .base import AgentOutput, BaseCLIAgent
-
+from collections.abc import Sequence
 
 class ClaudeAgent(BaseCLIAgent):
     """Claude CLI agent with system-prompt injection support."""
 
-    def _build_command(self, *, role: ResolvedCLIRole, system_prompt: str | None) -> list[str]:
+    def _build_command(
+        self,
+        *,
+        role: ResolvedCLIRole,
+        system_prompt: str | None,
+        allow_edits: bool = False,
+        editable_paths: Sequence[str] = (),
+    ) -> list[str]:
         command = list(self.client.executable)
         command.extend(self.client.internal_args)
-        command.extend(self.client.config_args)
 
-        if system_prompt and "--append-system-prompt" not in self.client.config_args:
+        config_args = self._sanitize_permission_args(
+            self.client.config_args,
+            allow_edits=allow_edits,
+        )
+        command.extend(config_args)
+
+        if system_prompt and "--append-system-prompt" not in config_args:
             command.extend(["--append-system-prompt", system_prompt])
+
+        if allow_edits and editable_paths:
+            for path in editable_paths:
+                command.extend(["--allowedTools", f"Edit({path})"])
+                command.extend(["--allowedTools", f"Write({path})"])
 
         command.extend(role.role_args)
         return command
@@ -47,3 +64,33 @@ class ClaudeAgent(BaseCLIAgent):
             parser_name=self._parser.name,
             output_file_content=output_file_content,
         )
+
+    def _sanitize_permission_args(self, args: list[str], *, allow_edits: bool) -> list[str]:
+        sanitized: list[str] = []
+        i = 0
+
+        while i < len(args):
+            arg = args[i]
+
+            if arg == "--permission-mode":
+                if i + 1 < len(args):
+                    mode = args[i + 1]
+
+                    if allow_edits:
+                        sanitized.extend([arg, mode])
+                    else:
+                        sanitized.extend([arg, "default"])
+
+                    i += 2
+                    continue
+
+            sanitized.append(arg)
+            i += 1
+
+        if "--permission-mode" not in sanitized:
+            sanitized.extend([
+                "--permission-mode",
+                "acceptEdits" if allow_edits else "default",
+            ])
+
+        return sanitized

--- a/clink/agents/claude.py
+++ b/clink/agents/claude.py
@@ -67,27 +67,23 @@ class ClaudeAgent(BaseCLIAgent):
 
     def _sanitize_permission_args(self, args: list[str], *, allow_edits: bool) -> list[str]:
         sanitized: list[str] = []
-        i = 0
+        found = False
 
-        while i < len(args):
-            arg = args[i]
-
+        it = iter(args)
+        for arg in it:
             if arg == "--permission-mode":
-                if i + 1 < len(args):
-                    mode = args[i + 1]
+                found = True
+                sanitized.append(arg)
+                try:
+                    _ = next(it)
+                except StopIteration:
+                    pass
 
-                    if allow_edits:
-                        sanitized.extend([arg, mode])
-                    else:
-                        sanitized.extend([arg, "default"])
+                sanitized.append("acceptEdits" if allow_edits else "default")
+            else:
+                sanitized.append(arg)
 
-                    i += 2
-                    continue
-
-            sanitized.append(arg)
-            i += 1
-
-        if "--permission-mode" not in sanitized:
+        if not found:
             sanitized.extend([
                 "--permission-mode",
                 "acceptEdits" if allow_edits else "default",

--- a/clink/agents/claude.py
+++ b/clink/agents/claude.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from clink.models import ResolvedCLIRole
 from clink.parsers.base import ParserError
 
 from .base import AgentOutput, BaseCLIAgent
-from collections.abc import Sequence
 
 
 class ClaudeAgent(BaseCLIAgent):

--- a/conf/cli_clients/claude.json
+++ b/conf/cli_clients/claude.json
@@ -1,6 +1,6 @@
 {
   "name": "claude",
-  "command": "E:/BucVe/pal-mcp/pal-mcp-server/.venv/Scripts/python.exe E:/BucVe/pal-mcp/poc/fake_claude.py",     
+  "command": "claude",     
   "additional_args": [
     "--permission-mode",
     "default",

--- a/conf/cli_clients/claude.json
+++ b/conf/cli_clients/claude.json
@@ -1,9 +1,9 @@
 {
   "name": "claude",
-  "command": "claude",
+  "command": "E:/BucVe/pal-mcp/pal-mcp-server/.venv/Scripts/python.exe E:/BucVe/pal-mcp/poc/fake_claude.py",     
   "additional_args": [
     "--permission-mode",
-    "acceptEdits",
+    "default",
     "--model",
     "sonnet"
   ],

--- a/simulator_tests/test_chat_simple_validation.py
+++ b/simulator_tests/test_chat_simple_validation.py
@@ -13,7 +13,6 @@ Comprehensive test for the new ChatSimple tool implementation that validates:
 - Conversation context preservation across turns
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_conversation_chain_validation.py
+++ b/simulator_tests/test_conversation_chain_validation.py
@@ -21,7 +21,6 @@ This validates the conversation threading system's ability to:
 - Properly traverse parent relationships for history reconstruction
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_cross_tool_comprehensive.py
+++ b/simulator_tests/test_cross_tool_comprehensive.py
@@ -12,7 +12,6 @@ Validates:
 5. Proper tool chaining with context
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_ollama_custom_url.py
+++ b/simulator_tests/test_ollama_custom_url.py
@@ -9,7 +9,6 @@ Tests custom API endpoint functionality with Ollama-style local models, includin
 - Model alias resolution for local models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_fallback.py
+++ b/simulator_tests/test_openrouter_fallback.py
@@ -8,7 +8,6 @@ Tests that verify the system correctly falls back to OpenRouter when:
 - Auto mode correctly selects OpenRouter models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_models.py
+++ b/simulator_tests/test_openrouter_models.py
@@ -9,7 +9,6 @@ Tests that verify OpenRouter functionality including:
 - Error handling when models are not available
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_xai_models.py
+++ b/simulator_tests/test_xai_models.py
@@ -9,7 +9,6 @@ Tests that verify X.AI GROK functionality including:
 - API integration and response validation
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/tests/test_directory_expansion_tracking.py
+++ b/tests/test_directory_expansion_tracking.py
@@ -37,8 +37,7 @@ class TestDirectoryExpansionTracking:
         files = []
         for i in range(5):
             swift_file = temp_path / f"File{i}.swift"
-            swift_file.write_text(
-                f"""
+            swift_file.write_text(f"""
 import Foundation
 
 class TestClass{i} {{
@@ -46,18 +45,15 @@ class TestClass{i} {{
         return "test{i}"
     }}
 }}
-"""
-            )
+""")
             files.append(str(swift_file))
 
         # Create a Python file as well
         python_file = temp_path / "helper.py"
-        python_file.write_text(
-            """
+        python_file.write_text("""
 def helper_function():
     return "helper"
-"""
-        )
+""")
         files.append(str(python_file))
 
         try:

--- a/tests/test_docker_implementation.py
+++ b/tests/test_docker_implementation.py
@@ -310,13 +310,11 @@ def temp_project_dir():
 
         # Create base files
         (temp_path / "server.py").write_text("# Mock server.py")
-        (temp_path / "Dockerfile").write_text(
-            """
+        (temp_path / "Dockerfile").write_text("""
 FROM python:3.11-slim
 COPY server.py /app/
 CMD ["python", "/app/server.py"]
-"""
-        )
+""")
 
         yield temp_path
 

--- a/tests/test_prompt_regression.py
+++ b/tests/test_prompt_regression.py
@@ -86,16 +86,14 @@ class TestPromptIntegration:
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def hello_world():
     \"\"\"A simple hello world function.\"\"\"
     return "Hello, World!"
 
 if __name__ == "__main__":
     print(hello_world())
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -155,8 +153,7 @@ if __name__ == "__main__":
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def process_user_input(user_input):
     # Potentially unsafe code for demonstration
     query = f"SELECT * FROM users WHERE name = '{user_input}'"
@@ -166,8 +163,7 @@ def main():
     user_name = input("Enter name: ")
     result = process_user_input(user_name)
     print(result)
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -241,8 +237,7 @@ def main():
 
         # Create a temporary Python file demonstrating MVC pattern
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 # Model
 class User:
     def __init__(self, name, email):
@@ -262,8 +257,7 @@ class UserController:
 
     def get_user_display(self):
         return self.view.display_user(self.model)
-"""
-            )
+""")
             temp_file = f.name
 
         try:

--- a/tools/clink.py
+++ b/tools/clink.py
@@ -50,6 +50,14 @@ class CLinkRequest(BaseModel):
         default=None,
         description=COMMON_FIELD_DESCRIPTIONS["continuation_id"],
     )
+    allow_edits: bool = Field(
+        default=False,
+        description="Explicitly allow filesystem edits by the CLI. Disabled by default for security.",
+    )
+    editable_paths: list[str] = Field(
+        default_factory=list,
+        description="Optional allow-list of absolute paths that may be edited when allow_edits=true.",
+    )
 
 
 class CLinkTool(SimpleTool):
@@ -140,6 +148,15 @@ class CLinkTool(SimpleTool):
                 "enum": self._all_roles or ["default"],
                 "description": role_description,
             },
+            "allow_edits": {
+                "type": "boolean",
+                "description": "Allow filesystem edits by the CLI. Defaults to false.",
+            },
+            "editable_paths": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Absolute paths allowed for editing when allow_edits=true.",
+            },
             "absolute_file_paths": SchemaBuilder.SIMPLE_FIELD_SCHEMAS["absolute_file_paths"],
             "images": SchemaBuilder.COMMON_FIELD_SCHEMAS["images"],
             "continuation_id": SchemaBuilder.COMMON_FIELD_SCHEMAS["continuation_id"],
@@ -164,6 +181,13 @@ class CLinkTool(SimpleTool):
     async def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
         self._current_arguments = arguments
         request = self.get_request_model()(**arguments)
+
+        if request.editable_paths and not request.allow_edits:
+            self._raise_tool_error("editable_paths requires allow_edits=true.")
+
+        editable_path_error = self._validate_editable_paths(request)
+        if editable_path_error:
+            self._raise_tool_error(editable_path_error)
 
         path_error = self._validate_file_paths(request)
         if path_error:
@@ -211,6 +235,8 @@ class CLinkTool(SimpleTool):
                 system_prompt=system_prompt_text if system_prompt_text.strip() else None,
                 files=absolute_file_paths,
                 images=images,
+                allow_edits=request.allow_edits,
+                editable_paths=request.editable_paths,
             )
         except CLIAgentError as exc:
             metadata = self._build_error_metadata(client_config, exc)
@@ -290,7 +316,12 @@ class CLinkTool(SimpleTool):
             if include_system_prompt and active_prompt:
                 sections.append(active_prompt)
             sections.append(guidance)
-            sections.append("=== USER REQUEST ===\n" + user_content)
+            sections.append("=== UNTRUSTED USER REQUEST ===\n" + user_content)
+            if not request.allow_edits:
+                sections.append(
+                    "=== EXECUTION POLICY ===\n"
+                    "You must NOT perform any filesystem modifications or apply edits."
+                )
             if file_section:
                 sections.append("=== FILE REFERENCES ===\n" + file_section)
             sections.append("Provide your response below using your own CLI tools as needed:")
@@ -461,3 +492,15 @@ class CLinkTool(SimpleTool):
             except OSError:
                 references.append(f"- {file_path} (unavailable)")
         return "\n".join(references)
+
+    def _validate_editable_paths(self, request: CLinkRequest) -> str | None:
+        for raw_path in request.editable_paths:
+            try:
+                path = Path(raw_path)
+            except Exception:
+                return f"Invalid editable path: {raw_path}"
+
+            if not path.is_absolute():
+                return f"editable_paths must be absolute paths: {raw_path}"
+
+        return None

--- a/tools/clink.py
+++ b/tools/clink.py
@@ -183,7 +183,7 @@ class CLinkTool(SimpleTool):
         request = self.get_request_model()(**arguments)
 
         if request.editable_paths and not request.allow_edits:
-            self._raise_tool_error("editable_paths requires allow_edits=true.")
+            self._raise_tool_error("editable_paths can only be used when allow_edits=true.")
 
         editable_path_error = self._validate_editable_paths(request)
         if editable_path_error:
@@ -497,7 +497,7 @@ class CLinkTool(SimpleTool):
         for raw_path in request.editable_paths:
             try:
                 path = Path(raw_path)
-            except Exception:
+            except (TypeError, ValueError):
                 return f"Invalid editable path: {raw_path}"
 
             if not path.is_absolute():

--- a/tools/clink.py
+++ b/tools/clink.py
@@ -319,8 +319,7 @@ class CLinkTool(SimpleTool):
             sections.append("=== UNTRUSTED USER REQUEST ===\n" + user_content)
             if not request.allow_edits:
                 sections.append(
-                    "=== EXECUTION POLICY ===\n"
-                    "You must NOT perform any filesystem modifications or apply edits."
+                    "=== EXECUTION POLICY ===\n" "You must NOT perform any filesystem modifications or apply edits."
                 )
             if file_section:
                 sections.append("=== FILE REFERENCES ===\n" + file_section)


### PR DESCRIPTION
## Summary

This PR improves the security posture of the `clink` tool by enforcing safe-by-default behavior when executing external AI CLIs.

Previously, untrusted prompt input could be forwarded directly to a CLI configured with automatic file edit permissions (e.g. `--permission-mode acceptEdits`), allowing unintended filesystem modifications.

## Changes

- Disable filesystem edits by default
- Introduce explicit opt-in (`allow_edits`) for write-capable CLI execution
- Enforce permission mode at runtime (not only via configuration)
- Add optional editable path allow-list (`editable_paths`)

## Security Impact

This change prevents untrusted remote input from triggering filesystem modifications without explicit authorization, enforcing a clear trust boundary between:

- Remote MCP client input
- Local CLI execution context

## Backward Compatibility

- Existing workflows remain functional when `allow_edits=true`
- Default behavior is now safer for remote/untrusted use cases

## Related Issue

Fixes #417

## Disclosure

This issue has been submitted to MITRE for CVE consideration.  
Full PoC and reproduction steps can be shared privately upon request.