### PR TITLE
fix(core): convert boot guard ValueError to warning for OAuth-native support

### DIFF
--- a/server.py
+++ b/server.py
@@ -540,16 +540,11 @@ def configure_providers():
     if registered_providers:
         logger.info(f"Registered providers: {', '.join(registered_providers)}")
 
-    # Require at least one valid provider
+    # Check if OAuth-native mode is enabled or warn instead of blocking
     if not valid_providers:
-        raise ValueError(
-            "At least one API configuration is required. Please set either:\n"
-            "- GEMINI_API_KEY for Gemini models\n"
-            "- OPENAI_API_KEY for OpenAI models\n"
-            "- XAI_API_KEY for X.AI GROK models\n"
-            "- DIAL_API_KEY for DIAL models\n"
-            "- OPENROUTER_API_KEY for OpenRouter (multiple models)\n"
-            "- CUSTOM_API_URL for local models (Ollama, vLLM, etc.)"
+        logger.warning(
+            "No API configurations found. Tools requiring an API model will fail. "
+            "However, OAuth-native local tools (like clink) will still function."
         )
 
     logger.info(f"Available providers: {', '.join(valid_providers)}")

--- a/simulator_tests/test_chat_simple_validation.py
+++ b/simulator_tests/test_chat_simple_validation.py
@@ -13,7 +13,6 @@ Comprehensive test for the new ChatSimple tool implementation that validates:
 - Conversation context preservation across turns
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_conversation_chain_validation.py
+++ b/simulator_tests/test_conversation_chain_validation.py
@@ -21,7 +21,6 @@ This validates the conversation threading system's ability to:
 - Properly traverse parent relationships for history reconstruction
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_cross_tool_comprehensive.py
+++ b/simulator_tests/test_cross_tool_comprehensive.py
@@ -12,7 +12,6 @@ Validates:
 5. Proper tool chaining with context
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_ollama_custom_url.py
+++ b/simulator_tests/test_ollama_custom_url.py
@@ -9,7 +9,6 @@ Tests custom API endpoint functionality with Ollama-style local models, includin
 - Model alias resolution for local models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_fallback.py
+++ b/simulator_tests/test_openrouter_fallback.py
@@ -8,7 +8,6 @@ Tests that verify the system correctly falls back to OpenRouter when:
 - Auto mode correctly selects OpenRouter models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_models.py
+++ b/simulator_tests/test_openrouter_models.py
@@ -9,7 +9,6 @@ Tests that verify OpenRouter functionality including:
 - Error handling when models are not available
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_xai_models.py
+++ b/simulator_tests/test_xai_models.py
@@ -9,7 +9,6 @@ Tests that verify X.AI GROK functionality including:
 - API integration and response validation
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/tests/test_custom_provider.py
+++ b/tests/test_custom_provider.py
@@ -309,13 +309,23 @@ class TestConfigureProvidersFunction:
             assert ProviderType.CUSTOM in available
 
     def test_configure_providers_no_valid_keys(self):
-        """Test configure_providers raises error when no valid API keys."""
+        """Test configure_providers logs a warning when no valid API keys."""
         from server import configure_providers
 
         with patch.dict(
             os.environ,
             {"GEMINI_API_KEY": "", "OPENAI_API_KEY": "", "OPENROUTER_API_KEY": "", "CUSTOM_API_URL": ""},
             clear=True,
-        ):
-            with pytest.raises(ValueError, match="At least one API configuration is required"):
-                configure_providers()
+        ), patch("server.logger") as mock_logger:
+            
+            valid_providers = configure_providers()
+            
+            # Verify no providers are returned or list is empty (function doesn't return anything natively in python but just in case)
+            if valid_providers is not None:
+                assert len(valid_providers) == 0
+            
+            # Verify it logged a warning instead of raising ValueError
+            mock_logger.warning.assert_called_once()
+            warning_msg = mock_logger.warning.call_args[0][0]
+            assert "No API configurations found" in warning_msg or "At least one API configuration is required" in warning_msg
+

--- a/tests/test_custom_provider.py
+++ b/tests/test_custom_provider.py
@@ -312,20 +312,25 @@ class TestConfigureProvidersFunction:
         """Test configure_providers logs a warning when no valid API keys."""
         from server import configure_providers
 
-        with patch.dict(
-            os.environ,
-            {"GEMINI_API_KEY": "", "OPENAI_API_KEY": "", "OPENROUTER_API_KEY": "", "CUSTOM_API_URL": ""},
-            clear=True,
-        ), patch("server.logger") as mock_logger:
-            
+        with (
+            patch.dict(
+                os.environ,
+                {"GEMINI_API_KEY": "", "OPENAI_API_KEY": "", "OPENROUTER_API_KEY": "", "CUSTOM_API_URL": ""},
+                clear=True,
+            ),
+            patch("server.logger") as mock_logger,
+        ):
+
             valid_providers = configure_providers()
-            
+
             # Verify no providers are returned or list is empty (function doesn't return anything natively in python but just in case)
             if valid_providers is not None:
                 assert len(valid_providers) == 0
-            
+
             # Verify it logged a warning instead of raising ValueError
             mock_logger.warning.assert_called_once()
             warning_msg = mock_logger.warning.call_args[0][0]
-            assert "No API configurations found" in warning_msg or "At least one API configuration is required" in warning_msg
-
+            assert (
+                "No API configurations found" in warning_msg
+                or "At least one API configuration is required" in warning_msg
+            )

--- a/tests/test_directory_expansion_tracking.py
+++ b/tests/test_directory_expansion_tracking.py
@@ -37,8 +37,7 @@ class TestDirectoryExpansionTracking:
         files = []
         for i in range(5):
             swift_file = temp_path / f"File{i}.swift"
-            swift_file.write_text(
-                f"""
+            swift_file.write_text(f"""
 import Foundation
 
 class TestClass{i} {{
@@ -46,18 +45,15 @@ class TestClass{i} {{
         return "test{i}"
     }}
 }}
-"""
-            )
+""")
             files.append(str(swift_file))
 
         # Create a Python file as well
         python_file = temp_path / "helper.py"
-        python_file.write_text(
-            """
+        python_file.write_text("""
 def helper_function():
     return "helper"
-"""
-        )
+""")
         files.append(str(python_file))
 
         try:

--- a/tests/test_docker_implementation.py
+++ b/tests/test_docker_implementation.py
@@ -310,13 +310,11 @@ def temp_project_dir():
 
         # Create base files
         (temp_path / "server.py").write_text("# Mock server.py")
-        (temp_path / "Dockerfile").write_text(
-            """
+        (temp_path / "Dockerfile").write_text("""
 FROM python:3.11-slim
 COPY server.py /app/
 CMD ["python", "/app/server.py"]
-"""
-        )
+""")
 
         yield temp_path
 

--- a/tests/test_prompt_regression.py
+++ b/tests/test_prompt_regression.py
@@ -86,16 +86,14 @@ class TestPromptIntegration:
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def hello_world():
     \"\"\"A simple hello world function.\"\"\"
     return "Hello, World!"
 
 if __name__ == "__main__":
     print(hello_world())
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -155,8 +153,7 @@ if __name__ == "__main__":
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def process_user_input(user_input):
     # Potentially unsafe code for demonstration
     query = f"SELECT * FROM users WHERE name = '{user_input}'"
@@ -166,8 +163,7 @@ def main():
     user_name = input("Enter name: ")
     result = process_user_input(user_name)
     print(result)
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -241,8 +237,7 @@ def main():
 
         # Create a temporary Python file demonstrating MVC pattern
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 # Model
 class User:
     def __init__(self, name, email):
@@ -262,8 +257,7 @@ class UserController:
 
     def get_user_display(self):
         return self.view.display_user(self.model)
-"""
-            )
+""")
             temp_file = f.name
 
         try:


### PR DESCRIPTION
# Description

This PR modifies the `configure_providers` "Boot Guard" constraint in `server.py` to allow the PAL MCP Server to run even when no API keys or configuration URLs are present. It changes the `ValueError` exception into a non-blocking `logger.warning`.

## Why is this important?

In zero-cost "OAuth-native" orchestration setups (like our architecture at Mandalay Jewelry / AAOS), the primary interaction method is via `CLinkTool`, which leverages local OS-authenticated CLI sessions (e.g. `gemini`, `codex`, `claude` CLIs). Since `clink` bypasses the model resolution requirements (`requires_model=False`), it is fully capable of operating without any API keys configured. 

Previously, PAL required a dummy local configuration (e.g., `CUSTOM_API_URL=http://localhost:11434`) just to bypass the boot guard. This PR removes that friction, allowing a true API-free, local OAUTH experience by default.

### Key Benefits:
- **Zero-Cost Operation**: Prioritizes local, already-authenticated CLI agent sessions.
- **Enhanced User Experience**: Prevents the server from crashing immediately if the user only wants to use native `clink` agents.
- **Backwards Compatible**: Tools that genuinely require an API model will still fail gracefully at runtime if no model is available, but the server itself remains up.

@guidedways / @fahad - Please review this change as a PoC for "No-API" orchestration enablement. Thank you!
