### PR TITLE
feat(clink): add grok CLI agent via a general prompt_to_file mechanism

### DIFF
--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -89,7 +89,9 @@ class BaseCLIAgent:
         start_time = time.monotonic()
 
         output_file_path: Path | None = None
+        prompt_file_path: Path | None = None
         command_with_output_flag = list(command)
+        stdin_bytes = prompt.encode("utf-8")
 
         if self.client.output_to_file:
             fd, tmp_path = tempfile.mkstemp(prefix="clink-", suffix=".json")
@@ -102,6 +104,39 @@ class BaseCLIAgent:
                 raise CLIAgentError(f"Invalid output flag template '{flag_template}': missing placeholder {exc}")
             command_with_output_flag.extend(shlex.split(rendered_flag))
             sanitized_command = list(command_with_output_flag)
+
+        if self.client.prompt_to_file:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                prefix="clink-",
+                suffix=".txt",
+                delete=False,
+            ) as tmp:
+                tmp.write(prompt)
+                prompt_file_path = Path(tmp.name)
+            flag_template = self.client.prompt_to_file.flag_template
+            # Split the template first, then substitute the path into each token, so a
+            # temp path containing spaces (common on Windows/macOS) stays a single arg
+            # instead of being re-split by shlex.
+            try:
+                rendered_args = [part.format(path=str(prompt_file_path)) for part in shlex.split(flag_template)]
+            except KeyError as exc:  # pragma: no cover - defensive
+                raise CLIAgentError(f"Invalid prompt flag template '{flag_template}': missing placeholder {exc}")
+            command_with_output_flag.extend(rendered_args)
+            sanitized_command = list(command_with_output_flag)
+            stdin_bytes = b""
+
+        def _cleanup_prompt_file() -> None:
+            # prompt_to_file agents receive the prompt via a temp file; remove it on
+            # every exit path (success, non-zero exit, parse error, timeout, launch
+            # failure) so prompts never linger on disk. Best-effort and idempotent —
+            # missing_ok covers a CLI that consumed/removed the file itself.
+            if prompt_file_path is not None and self.client.prompt_to_file and self.client.prompt_to_file.cleanup:
+                try:
+                    prompt_file_path.unlink(missing_ok=True)
+                except OSError:  # pragma: no cover - best effort cleanup
+                    pass
 
         self._logger.debug("Executing CLI command: %s", " ".join(sanitized_command))
         if cwd:
@@ -118,16 +153,18 @@ class BaseCLIAgent:
                 env=env,
             )
         except FileNotFoundError as exc:
+            _cleanup_prompt_file()
             raise CLIAgentError(f"Executable not found for CLI '{self.client.name}': {exc}") from exc
 
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                process.communicate(prompt.encode("utf-8")),
+                process.communicate(stdin_bytes),
                 timeout=self.client.timeout_seconds,
             )
         except asyncio.TimeoutError as exc:
             process.kill()
             await process.communicate()
+            _cleanup_prompt_file()
             raise CLIAgentError(
                 f"CLI '{self.client.name}' timed out after {self.client.timeout_seconds} seconds",
                 returncode=None,
@@ -148,6 +185,8 @@ class BaseCLIAgent:
 
             if output_file_content and not stdout_text.strip():
                 stdout_text = output_file_content
+
+        _cleanup_prompt_file()
 
         if return_code != 0:
             recovered = self._recover_from_error(

--- a/clink/constants.py
+++ b/clink/constants.py
@@ -45,4 +45,10 @@ INTERNAL_DEFAULTS: dict[str, CLIInternalDefaults] = {
         default_role_prompt="systemprompts/clink/default.txt",
         runner="claude",
     ),
+    "grok": CLIInternalDefaults(
+        parser="grok_json",
+        additional_args=["--output-format", "json", "--always-approve"],
+        default_role_prompt="systemprompts/clink/default.txt",
+        runner=None,
+    ),
 }

--- a/clink/models.py
+++ b/clink/models.py
@@ -18,6 +18,18 @@ class OutputCaptureConfig(BaseModel):
     )
 
 
+class PromptFileConfig(BaseModel):
+    """Optional configuration for CLIs that read the prompt from a file."""
+
+    flag_template: str = Field(
+        ..., description="Template used to inject the prompt file path, e.g. '--prompt-file {path}'."
+    )
+    cleanup: bool = Field(
+        default=True,
+        description="Whether the temporary file should be removed after execution.",
+    )
+
+
 class CLIRoleConfig(BaseModel):
     """Role-specific configuration loaded from JSON manifests."""
 
@@ -51,6 +63,7 @@ class CLIClientConfig(BaseModel):
     timeout_seconds: PositiveInt | None = Field(default=None)
     roles: dict[str, CLIRoleConfig] = Field(default_factory=dict)
     output_to_file: OutputCaptureConfig | None = None
+    prompt_to_file: PromptFileConfig | None = None
 
     @field_validator("additional_args", mode="before")
     @classmethod
@@ -87,6 +100,7 @@ class ResolvedCLIClient(BaseModel):
     runner: str | None = None
     roles: dict[str, ResolvedCLIRole]
     output_to_file: OutputCaptureConfig | None = None
+    prompt_to_file: PromptFileConfig | None = None
 
     def list_roles(self) -> list[str]:
         return list(self.roles.keys())

--- a/clink/parsers/__init__.py
+++ b/clink/parsers/__init__.py
@@ -6,11 +6,13 @@ from .base import BaseParser, ParsedCLIResponse, ParserError
 from .claude import ClaudeJSONParser
 from .codex import CodexJSONLParser
 from .gemini import GeminiJSONParser
+from .grok import GrokJSONParser
 
 _PARSER_CLASSES: dict[str, type[BaseParser]] = {
     CodexJSONLParser.name: CodexJSONLParser,
     GeminiJSONParser.name: GeminiJSONParser,
     ClaudeJSONParser.name: ClaudeJSONParser,
+    GrokJSONParser.name: GrokJSONParser,
 }
 
 

--- a/clink/parsers/grok.py
+++ b/clink/parsers/grok.py
@@ -1,0 +1,67 @@
+"""Parser for grok CLI JSON output."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .base import BaseParser, ParsedCLIResponse, ParserError
+
+
+class GrokJSONParser(BaseParser):
+    """Parse stdout produced by `grok --output-format json`.
+
+    grok emits a single JSON object on stdout::
+
+        {"text":"...","stopReason":"EndTurn","sessionId":"...","requestId":"..."}
+
+    Log or MCP noise may appear on stderr — it is ignored.  If leading junk
+    appears before the opening brace on stdout (e.g. progress lines) we slice
+    from the first ``{``.
+    """
+
+    name = "grok_json"
+
+    def parse(self, stdout: str, stderr: str) -> ParsedCLIResponse:
+        if not stdout.strip():
+            raise ParserError("grok CLI returned empty stdout while JSON output was expected")
+
+        # Find the first decodable JSON object on stdout. We try every "{" rather than
+        # only the first, because a leading log/progress line may itself contain "{"
+        # (e.g. "Connecting to {endpoint}"); raw_decode also ignores any output that
+        # trails the object.
+        decoder = json.JSONDecoder()
+        payload: dict[str, Any] | None = None
+        last_error: json.JSONDecodeError | None = None
+        index = stdout.find("{")
+        while index != -1:
+            try:
+                candidate, _ = decoder.raw_decode(stdout[index:])
+            except json.JSONDecodeError as exc:
+                last_error = exc
+            else:
+                if isinstance(candidate, dict):
+                    payload = candidate
+                    break
+            index = stdout.find("{", index + 1)
+
+        if payload is None:
+            if last_error is not None:
+                raise ParserError(f"Failed to decode grok CLI JSON output: {last_error}") from last_error
+            raise ParserError(f"grok CLI stdout contains no JSON object: {stdout[:200]!r}")
+
+        text = payload.get("text")
+        if not isinstance(text, str) or not text.strip():
+            raise ParserError("grok CLI JSON response is missing a non-empty 'text' field")
+
+        metadata: dict[str, Any] = {"raw": payload}
+        if payload.get("stopReason"):
+            metadata["stop_reason"] = payload["stopReason"]
+        if payload.get("sessionId"):
+            metadata["session_id"] = payload["sessionId"]
+        if payload.get("requestId"):
+            metadata["request_id"] = payload["requestId"]
+        if stderr and stderr.strip():
+            metadata["stderr"] = stderr.strip()
+
+        return ParsedCLIResponse(content=text.strip(), metadata=metadata)

--- a/clink/registry.py
+++ b/clink/registry.py
@@ -156,6 +156,7 @@ class ClinkRegistry:
         roles = self._resolve_roles(raw, internal_defaults, source_path)
 
         output_to_file = raw.output_to_file
+        prompt_to_file = raw.prompt_to_file
 
         return ResolvedCLIClient(
             name=normalized_name,
@@ -168,6 +169,7 @@ class ClinkRegistry:
             runner=runner_name,
             roles=roles,
             output_to_file=output_to_file,
+            prompt_to_file=prompt_to_file,
             working_dir=working_dir,
         )
 

--- a/conf/cli_clients/grok.json
+++ b/conf/cli_clients/grok.json
@@ -1,0 +1,10 @@
+{
+  "name": "grok",
+  "command": "grok",
+  "additional_args": [],
+  "env": {},
+  "prompt_to_file": {"flag_template": "--prompt-file {path}"},
+  "roles": {
+    "default": {"prompt_path": "systemprompts/clink/default.txt", "role_args": []}
+  }
+}

--- a/docs/tools/clink.md
+++ b/docs/tools/clink.md
@@ -78,7 +78,7 @@ You can make your own custom roles in `conf/cli_clients/` or tweak any of the sh
 ## Tool Parameters
 
 - `prompt`: Your question or task for the external CLI (required)
-- `cli_name`: Which CLI to use - `gemini` (default), `claude`, `codex`, or add your own in `conf/cli_clients/`
+- `cli_name`: Which CLI to use - `gemini` (default), `claude`, `codex`, `grok`, or add your own in `conf/cli_clients/`
 - `role`: Preset role - `default`, `planner`, `codereviewer` (default: `default`)
 - `files`: Optional file paths for context (references only, CLI opens files itself)
 - `images`: Optional image paths for visual context
@@ -141,6 +141,7 @@ Clink configurations live in `conf/cli_clients/`. We ship presets for the suppor
 - `gemini.json` – runs `gemini --telemetry false --yolo -o json`
 - `claude.json` – runs `claude --print --output-format json --permission-mode acceptEdits --model sonnet`
 - `codex.json` – runs `codex exec --json --dangerously-bypass-approvals-and-sandbox`
+- `grok.json` – runs `grok --output-format json --always-approve` with the prompt delivered via `--prompt-file` (grok does not read stdin); authenticates through the local grok CLI session (no API key)
 
 > **CAUTION**: These flags intentionally bypass each CLI's safety prompts so they can edit files or launch tools autonomously via MCP. Only enable them in trusted sandboxes and tailor role prompts or CLI configs if you need more guardrails.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 pytest>=7.4.0
 pytest-asyncio>=0.21.0
 pytest-mock>=3.11.0
-black>=23.0.0
-ruff>=0.1.0
-isort>=5.12.0
+black==25.1.0
+ruff==0.12.8
+isort==6.0.1
 python-semantic-release>=10.3.0
 build>=1.0.0

--- a/tests/test_clink_grok_agent.py
+++ b/tests/test_clink_grok_agent.py
@@ -1,0 +1,138 @@
+import asyncio
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from clink.agents.base import BaseCLIAgent
+from clink.models import PromptFileConfig, ResolvedCLIClient, ResolvedCLIRole
+
+
+class DummyProcess:
+    def __init__(self, *, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self.stdin_data: bytes | None = None
+
+    async def communicate(self, input_data):
+        self.stdin_data = input_data
+        return self._stdout, self._stderr
+
+
+@pytest.fixture()
+def grok_agent():
+    prompt_path = Path("systemprompts/clink/default.txt").resolve()
+    role = ResolvedCLIRole(name="default", prompt_path=prompt_path, role_args=[])
+    client = ResolvedCLIClient(
+        name="grok",
+        executable=["grok"],
+        internal_args=["--output-format", "json", "--always-approve"],
+        config_args=[],
+        env={},
+        timeout_seconds=30,
+        parser="grok_json",
+        runner=None,
+        roles={"default": role},
+        output_to_file=None,
+        prompt_to_file=PromptFileConfig(flag_template="--prompt-file {path}"),
+        working_dir=None,
+    )
+    return BaseCLIAgent(client), role
+
+
+async def _run_agent_with_process(monkeypatch, agent, role, process, *, prompt="do something"):
+    captured: dict = {"command": [], "prompt_file_content": None}
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        captured["command"].extend(args)
+        # The prompt file is written before launch and only cleaned up after
+        # communicate() returns, so it is readable here — capture its content to
+        # prove the prompt is actually delivered via the file (not stdin).
+        if "--prompt-file" in args:
+            path = Path(args[args.index("--prompt-file") + 1])
+            captured["prompt_file_content"] = path.read_text(encoding="utf-8")
+        return process
+
+    def fake_which(executable_name):
+        return f"/usr/bin/{executable_name}"
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(shutil, "which", fake_which)
+    result = await agent.run(role=role, prompt=prompt, files=[], images=[])
+    return result, captured
+
+
+@pytest.mark.asyncio
+async def test_prompt_to_file_writes_temp_and_uses_empty_stdin(monkeypatch, grok_agent):
+    agent, role = grok_agent
+    process = DummyProcess(
+        stdout=json.dumps({"text": "ok", "stopReason": "EndTurn"}).encode(),
+    )
+
+    result, captured = await _run_agent_with_process(monkeypatch, agent, role, process, prompt="my prompt content")
+
+    assert "--prompt-file" in captured["command"]
+    flag_idx = captured["command"].index("--prompt-file")
+    prompt_file_path = Path(captured["command"][flag_idx + 1])
+    # the prompt was delivered via the file (not stdin) and the file is cleaned up
+    assert captured["prompt_file_content"] == "my prompt content"
+    assert process.stdin_data == b""
+    assert not prompt_file_path.exists()
+    assert result.parsed.content == "ok"
+
+
+@pytest.mark.asyncio
+async def test_prompt_to_file_respects_cleanup_false(monkeypatch, grok_agent):
+    agent, role = grok_agent
+    agent.client.prompt_to_file = PromptFileConfig(flag_template="--prompt-file {path}", cleanup=False)
+    process = DummyProcess(stdout=json.dumps({"text": "kept"}).encode())
+
+    _, captured = await _run_agent_with_process(monkeypatch, agent, role, process)
+
+    prompt_file_path = Path(captured["command"][captured["command"].index("--prompt-file") + 1])
+    try:
+        assert prompt_file_path.exists()  # cleanup=False leaves the file in place
+    finally:
+        prompt_file_path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_prompt_to_file_path_with_spaces_stays_single_arg(monkeypatch, tmp_path, grok_agent):
+    import tempfile
+
+    agent, role = grok_agent
+    spaced = tmp_path / "dir with spaces"
+    spaced.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(spaced))  # temp file lands in a spaced dir
+    process = DummyProcess(stdout=json.dumps({"text": "ok"}).encode())
+
+    _, captured = await _run_agent_with_process(monkeypatch, agent, role, process)
+
+    cmd = captured["command"]
+    prompt_arg = cmd[cmd.index("--prompt-file") + 1]
+    # the spaced path must survive as ONE argument (not re-split by shlex)
+    assert " " in prompt_arg
+    assert Path(prompt_arg).parent == spaced
+
+
+@pytest.mark.asyncio
+async def test_grok_agent_parses_json_stdout(monkeypatch, grok_agent):
+    agent, role = grok_agent
+    stdout_payload = json.dumps(
+        {
+            "text": "Hello from grok",
+            "stopReason": "EndTurn",
+            "sessionId": "sess-abc",
+            "requestId": "req-def",
+        }
+    ).encode()
+    process = DummyProcess(stdout=stdout_payload)
+
+    result, _ = await _run_agent_with_process(monkeypatch, agent, role, process)
+
+    assert result.returncode == 0
+    assert result.parsed.content == "Hello from grok"
+    assert result.parsed.metadata["session_id"] == "sess-abc"
+    assert result.parsed.metadata["stop_reason"] == "EndTurn"

--- a/tests/test_clink_grok_parser.py
+++ b/tests/test_clink_grok_parser.py
@@ -1,0 +1,107 @@
+"""Tests for the grok CLI JSON parser."""
+
+import json
+
+import pytest
+
+from clink.parsers.base import ParserError
+from clink.parsers.grok import GrokJSONParser
+
+
+def _build_grok_stdout(*, text: str = "Hello from grok", extra: dict | None = None) -> str:
+    payload = {
+        "text": text,
+        "stopReason": "EndTurn",
+        "sessionId": "sess-123",
+        "requestId": "req-456",
+    }
+    if extra:
+        payload.update(extra)
+    return json.dumps(payload)
+
+
+def test_grok_parser_success():
+    parser = GrokJSONParser()
+    stdout = _build_grok_stdout(text="  Response text  ")
+
+    parsed = parser.parse(stdout, stderr="")
+
+    assert parsed.content == "Response text"
+    assert parsed.metadata["session_id"] == "sess-123"
+    assert parsed.metadata["stop_reason"] == "EndTurn"
+    assert parsed.metadata["request_id"] == "req-456"
+
+
+def test_grok_parser_tolerates_leading_noise_before_brace():
+    parser = GrokJSONParser()
+    stdout = "Loading model...\n" + _build_grok_stdout()
+
+    parsed = parser.parse(stdout, stderr="")
+
+    assert parsed.content == "Hello from grok"
+
+
+def test_grok_parser_includes_stderr_in_metadata():
+    parser = GrokJSONParser()
+    stdout = _build_grok_stdout()
+
+    parsed = parser.parse(stdout, stderr="  some log line  ")
+
+    assert parsed.metadata["stderr"] == "some log line"
+
+
+def test_grok_parser_empty_stdout_raises():
+    parser = GrokJSONParser()
+
+    with pytest.raises(ParserError, match="empty stdout"):
+        parser.parse(stdout="", stderr="")
+
+
+def test_grok_parser_no_brace_raises():
+    parser = GrokJSONParser()
+
+    with pytest.raises(ParserError, match="no JSON object"):
+        parser.parse(stdout="not json at all", stderr="")
+
+
+def test_grok_parser_malformed_json_raises_decode_error():
+    parser = GrokJSONParser()
+
+    # brace is present but the JSON is malformed -> exercises the decode-error branch
+    with pytest.raises(ParserError, match="Failed to decode"):
+        parser.parse(stdout="{not valid json", stderr="")
+
+
+def test_grok_parser_tolerates_trailing_output_after_object():
+    parser = GrokJSONParser()
+    stdout = _build_grok_stdout() + "\nDone in 2.1s\n"
+
+    parsed = parser.parse(stdout, stderr="")
+
+    assert parsed.content == "Hello from grok"
+
+
+def test_grok_parser_skips_leading_noise_containing_brace():
+    parser = GrokJSONParser()
+    # a leading log line that itself contains "{" must not derail the decode
+    stdout = "Connecting to {endpoint}...\n" + _build_grok_stdout()
+
+    parsed = parser.parse(stdout, stderr="")
+
+    assert parsed.content == "Hello from grok"
+
+
+def test_grok_parser_missing_text_raises():
+    parser = GrokJSONParser()
+    stdout = json.dumps({"stopReason": "EndTurn", "sessionId": "sess-123"})
+
+    with pytest.raises(ParserError, match="missing a non-empty 'text' field"):
+        parser.parse(stdout, stderr="")
+
+
+def test_grok_parser_empty_text_raises():
+    parser = GrokJSONParser()
+    stdout = json.dumps({"text": "   ", "stopReason": "EndTurn"})
+
+    with pytest.raises(ParserError, match="missing a non-empty 'text' field"):
+        parser.parse(stdout, stderr="")


### PR DESCRIPTION
## What

Adds xAI's **grok** CLI as a first-class `clink` agent, so an orchestrator (e.g. Claude Code) can delegate spec'd tasks to grok over MCP — the same way clink already supports gemini/claude/codex.

## Why a new `prompt_to_file` mechanism (not a grok special-case)

grok differs from the existing agents in exactly one way: **it cannot read the prompt from stdin** — it takes the prompt via a `--prompt-file <path>` flag. Rather than special-casing grok in `BaseCLIAgent`, this introduces a general, opt-in `prompt_to_file` client-config option, **symmetric with the existing `output_to_file`**:

- When a client sets `prompt_to_file`, the base agent writes the prompt to a temp file, appends the rendered flag (e.g. `--prompt-file {path}`), sends empty stdin, and removes the temp file on **every** exit path (success, non-zero exit, parse error, timeout, launch failure).
- When unset, the stdin path is **byte-identical** to before — existing agents (gemini/claude/codex) are unaffected.
- Any future stdin-less CLI can reuse the same mechanism with zero new code.

## Changes

| File | Change |
|------|--------|
| `clink/models.py` | `PromptFileConfig` + `prompt_to_file` field on `CLIClientConfig`/`ResolvedCLIClient` |
| `clink/registry.py` | thread `prompt_to_file` through resolution |
| `clink/agents/base.py` | prompt-file delivery + guaranteed temp-file cleanup in `run()` |
| `clink/constants.py` | register `grok` (`parser=grok_json`, `runner=None` → `BaseCLIAgent`) |
| `clink/parsers/grok.py` + `__init__.py` | `GrokJSONParser` for `grok --output-format json` (uses `raw_decode`, tolerant of trailing output) |
| `conf/cli_clients/grok.json` | preset: `command: "grok"` + `prompt_to_file` |
| `docs/tools/clink.md` | document the grok preset |
| `tests/test_clink_grok_*.py` | parser + agent/`prompt_to_file` coverage |

## Auth

grok authenticates via the **local grok CLI** session (SuperGrok subscription) — no `XAI_API_KEY` required, consistent with how the gemini/claude presets rely on their CLIs' own auth.

## Testing

`pytest -k "clink and not integration"` → **32 passed**. New tests cover: the `prompt_to_file` path (prompt delivered via file, empty stdin, cleanup on success, `cleanup=False` retention), and the grok parser (success, leading-noise tolerance, trailing-output tolerance, malformed-JSON, missing/empty `text`). Existing gemini/claude/codex agent + parser tests are unchanged and green. (The two `test_clink_integration.py` cases require live gemini/claude credentials and are unrelated to this change.)
