### PR TITLE
fix(clink): place codex --enable flags before exec subcommand

### DIFF
--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -192,6 +192,7 @@ class BaseCLIAgent:
 
     def _build_command(self, *, role: ResolvedCLIRole, system_prompt: str | None) -> list[str]:
         base = list(self.client.executable)
+        base.extend(self.client.pre_subcommand_args)
         base.extend(self.client.internal_args)
         base.extend(self.client.config_args)
         base.extend(role.role_args)

--- a/clink/agents/claude.py
+++ b/clink/agents/claude.py
@@ -13,6 +13,7 @@ class ClaudeAgent(BaseCLIAgent):
 
     def _build_command(self, *, role: ResolvedCLIRole, system_prompt: str | None) -> list[str]:
         command = list(self.client.executable)
+        command.extend(self.client.pre_subcommand_args)
         command.extend(self.client.internal_args)
         command.extend(self.client.config_args)
 

--- a/clink/models.py
+++ b/clink/models.py
@@ -47,12 +47,16 @@ class CLIClientConfig(BaseModel):
     command: str | None = None
     working_dir: str | None = None
     additional_args: list[str] = Field(default_factory=list)
+    pre_subcommand_args: list[str] = Field(
+        default_factory=list,
+        description="Flags that must appear after the executable but before the subcommand (e.g. codex --enable).",
+    )
     env: dict[str, str] = Field(default_factory=dict)
     timeout_seconds: PositiveInt | None = Field(default=None)
     roles: dict[str, CLIRoleConfig] = Field(default_factory=dict)
     output_to_file: OutputCaptureConfig | None = None
 
-    @field_validator("additional_args", mode="before")
+    @field_validator("additional_args", "pre_subcommand_args", mode="before")
     @classmethod
     def _ensure_args_list(cls, value: Any) -> list[str]:
         if value is None:
@@ -61,7 +65,7 @@ class CLIClientConfig(BaseModel):
             return [str(item) for item in value]
         if isinstance(value, str):
             return [value]
-        raise TypeError("additional_args must be a list of strings or a single string")
+        raise TypeError("args must be a list of strings or a single string")
 
 
 class ResolvedCLIRole(BaseModel):
@@ -80,6 +84,7 @@ class ResolvedCLIClient(BaseModel):
     executable: list[str]
     working_dir: Path | None
     internal_args: list[str] = Field(default_factory=list)
+    pre_subcommand_args: list[str] = Field(default_factory=list)
     config_args: list[str] = Field(default_factory=list)
     env: dict[str, str] = Field(default_factory=dict)
     timeout_seconds: int

--- a/clink/registry.py
+++ b/clink/registry.py
@@ -137,6 +137,7 @@ class ClinkRegistry:
         executable = self._resolve_executable(raw, internal_defaults, source_path)
 
         internal_args = list(internal_defaults.additional_args) if internal_defaults else []
+        pre_subcommand_args = list(raw.pre_subcommand_args)
         config_args = list(raw.additional_args)
 
         timeout_seconds = raw.timeout_seconds or (
@@ -161,6 +162,7 @@ class ClinkRegistry:
             name=normalized_name,
             executable=executable,
             internal_args=internal_args,
+            pre_subcommand_args=pre_subcommand_args,
             config_args=config_args,
             env=env,
             timeout_seconds=int(timeout_seconds),

--- a/conf/cli_clients/codex.json
+++ b/conf/cli_clients/codex.json
@@ -1,11 +1,13 @@
 {
   "name": "codex",
   "command": "codex",
-  "additional_args": [
-    "--json",
-    "--dangerously-bypass-approvals-and-sandbox",
+  "pre_subcommand_args": [
     "--enable",
     "web_search_request"
+  ],
+  "additional_args": [
+    "--json",
+    "--dangerously-bypass-approvals-and-sandbox"
   ],
   "env": {},
   "roles": {

--- a/docs/tools/clink.md
+++ b/docs/tools/clink.md
@@ -140,7 +140,7 @@ Clink configurations live in `conf/cli_clients/`. We ship presets for the suppor
 
 - `gemini.json` – runs `gemini --telemetry false --yolo -o json`
 - `claude.json` – runs `claude --print --output-format json --permission-mode acceptEdits --model sonnet`
-- `codex.json` – runs `codex exec --json --dangerously-bypass-approvals-and-sandbox`
+- `codex.json` – runs `codex --enable web_search_request exec --json --dangerously-bypass-approvals-and-sandbox`
 
 > **CAUTION**: These flags intentionally bypass each CLI's safety prompts so they can edit files or launch tools autonomously via MCP. Only enable them in trusted sandboxes and tailor role prompts or CLI configs if you need more guardrails.
 

--- a/tests/test_clink_codex_agent.py
+++ b/tests/test_clink_codex_agent.py
@@ -66,6 +66,29 @@ async def test_codex_agent_recovers_jsonl(monkeypatch, codex_agent):
 
 
 @pytest.mark.asyncio
+async def test_codex_agent_builds_command_with_pre_subcommand_args(codex_agent):
+    agent, role = codex_agent
+    client = agent.client.model_copy(
+        update={
+            "pre_subcommand_args": ["--enable", "web_search_request"],
+            "config_args": ["--json", "--dangerously-bypass-approvals-and-sandbox"],
+        }
+    )
+    agent = CodexAgent(client)
+
+    command = agent._build_command(role=role, system_prompt=None)
+
+    assert command == [
+        "codex",
+        "--enable",
+        "web_search_request",
+        "exec",
+        "--json",
+        "--dangerously-bypass-approvals-and-sandbox",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_codex_agent_propagates_invalid_json(monkeypatch, codex_agent):
     agent, role = codex_agent
     stdout = b"not json"

--- a/tests/test_clink_tool.py
+++ b/tests/test_clink_tool.py
@@ -60,12 +60,10 @@ def test_registry_lists_roles():
     assert "default" in roles
     assert "default" in registry.list_roles("codex")
     codex_client = registry.get_client("codex")
-    # Verify codex uses --enable web_search_request (not --search which is unsupported by exec)
+    assert codex_client.pre_subcommand_args == ["--enable", "web_search_request"]
     assert codex_client.config_args == [
         "--json",
         "--dangerously-bypass-approvals-and-sandbox",
-        "--enable",
-        "web_search_request",
     ]
 
 


### PR DESCRIPTION
## Summary

Fixes `clink codex` failures caused by passing `--enable web_search_request` to the `exec` subcommand instead of as a top-level codex flag.

## Motivation

Codex CLI expects top-level flags before the subcommand:

```
codex --enable web_search_request exec --json --dangerously-bypass-approvals-and-sandbox "prompt"
```

The previous config placed `--enable web_search_request` in `additional_args`, which are appended after `exec`, producing an invalid command (same class of bug as #338 with `--search`).

Fixes #387

## Changes

- Add `pre_subcommand_args` field to clink CLI config (`CLIClientConfig` / `ResolvedCLIClient`)
- Insert `pre_subcommand_args` after the executable and before `internal_args` in command assembly (`BaseCLIAgent`, `ClaudeAgent`)
- Move `--enable web_search_request` from `additional_args` to `pre_subcommand_args` in `conf/cli_clients/codex.json`
- Add unit test for command argument ordering
- Update `docs/tools/clink.md` preset description

## Tests

```bash
pytest tests/test_clink_codex_agent.py tests/test_clink_tool.py tests/test_clink_claude_agent.py -xvs
# 11 passed
```

## Notes

- `pre_subcommand_args` defaults to `[]`, so existing gemini/claude configs are unchanged.
- Users with a local override at `~/.pal/cli_clients/codex.json` should move `--enable web_search_request` from `additional_args` to `pre_subcommand_args`.