### PR TITLE
fix(clink): resolve codex CLI from nvm/npm global paths

### DIFF
--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import os
 import shlex
-import shutil
 import tempfile
 import time
 from collections.abc import Sequence
@@ -16,6 +15,7 @@ from pathlib import Path
 from clink.constants import DEFAULT_STREAM_LIMIT
 from clink.models import ResolvedCLIClient, ResolvedCLIRole
 from clink.parsers import BaseParser, ParsedCLIResponse, ParserError, get_parser
+from clink.path_resolution import augment_path, resolve_cli_executable
 
 logger = logging.getLogger("clink.agent")
 
@@ -70,13 +70,14 @@ class BaseCLIAgent:
 
         # Resolve executable path for cross-platform compatibility (especially Windows)
         executable_name = command[0]
-        resolved_executable = shutil.which(executable_name)
+        resolved_executable = resolve_cli_executable(executable_name, path=env.get("PATH"))
         if resolved_executable is None:
             raise CLIAgentError(
                 f"Executable '{executable_name}' not found in PATH for CLI '{self.client.name}'. "
                 f"Ensure the command is installed and accessible."
             )
         command[0] = resolved_executable
+        env["PATH"] = augment_path(env.get("PATH"))
 
         sanitized_command = list(command)
 

--- a/clink/path_resolution.py
+++ b/clink/path_resolution.py
@@ -1,0 +1,62 @@
+"""Resolve CLI executables when the host PATH omits user-local installs."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+
+def _candidate_path_dirs() -> list[str]:
+    """Return common directories for globally installed CLIs (nvm, npm, etc.)."""
+    home = Path.home()
+    candidates: list[str] = []
+
+    nvm_dir = Path(os.environ.get("NVM_DIR", str(home / ".nvm")))
+    versions_dir = nvm_dir / "versions" / "node"
+    if versions_dir.is_dir():
+        version_bins = sorted(versions_dir.glob("*/bin"), reverse=True)
+        candidates.extend(str(path) for path in version_bins)
+
+    for relative in (".local/bin", ".npm-global/bin", ".cargo/bin", "bin"):
+        candidate = home / relative
+        if candidate.is_dir():
+            candidates.append(str(candidate))
+
+    for system_path in ("/opt/homebrew/bin", "/usr/local/bin"):
+        if Path(system_path).is_dir():
+            candidates.append(system_path)
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for candidate in candidates:
+        if candidate not in seen:
+            seen.add(candidate)
+            unique.append(candidate)
+    return unique
+
+
+def augment_path(path: str | None, extra_dirs: list[str] | None = None) -> str:
+    """Prepend discovered user-local directories to PATH."""
+    dirs = extra_dirs if extra_dirs is not None else _candidate_path_dirs()
+    if not dirs:
+        return path or ""
+    prefix = os.pathsep.join(dirs)
+    if not path:
+        return prefix
+    return f"{prefix}{os.pathsep}{path}"
+
+
+def resolve_cli_executable(name: str, *, path: str | None = None) -> str | None:
+    """Locate a CLI executable, including npm/nvm global install locations."""
+    current_path = path if path is not None else os.environ.get("PATH")
+
+    resolved = shutil.which(name, path=current_path)
+    if resolved is not None:
+        return resolved
+
+    augmented = augment_path(current_path)
+    if augmented == current_path:
+        return None
+
+    return shutil.which(name, path=augmented)

--- a/tests/test_clink_claude_agent.py
+++ b/tests/test_clink_claude_agent.py
@@ -46,7 +46,7 @@ async def _run_agent_with_process(monkeypatch, agent, role, process, *, system_p
     async def fake_create_subprocess_exec(*_args, **_kwargs):
         return process
 
-    def fake_which(executable_name):
+    def fake_which(executable_name, path=None):
         return f"/usr/bin/{executable_name}"
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)

--- a/tests/test_clink_codex_agent.py
+++ b/tests/test_clink_codex_agent.py
@@ -42,7 +42,7 @@ async def _run_agent_with_process(monkeypatch, agent, role, process):
     async def fake_create_subprocess_exec(*_args, **_kwargs):
         return process
 
-    def fake_which(executable_name):
+    def fake_which(executable_name, path=None):
         return f"/usr/bin/{executable_name}"
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)

--- a/tests/test_clink_codex_path_resolution.py
+++ b/tests/test_clink_codex_path_resolution.py
@@ -60,7 +60,9 @@ async def test_codex_agent_resolves_nvm_installed_binary(monkeypatch, codex_agen
     async def fake_create_subprocess_exec(*args, **_kwargs):
         captured["args"] = args
         captured["env"] = _kwargs.get("env")
-        return DummyProcess(stdout=b'{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}', returncode=0)
+        return DummyProcess(
+            stdout=b'{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}', returncode=0
+        )
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
 

--- a/tests/test_clink_codex_path_resolution.py
+++ b/tests/test_clink_codex_path_resolution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import stat
 from pathlib import Path
 
@@ -68,4 +69,4 @@ async def test_codex_agent_resolves_nvm_installed_binary(monkeypatch, codex_agen
     assert captured["args"][0] == str(codex_path)
     env = captured["env"]
     assert env is not None
-    assert str(nvm_bin) in env["PATH"].split(":")
+    assert str(nvm_bin) in env["PATH"].split(os.pathsep)

--- a/tests/test_clink_codex_path_resolution.py
+++ b/tests/test_clink_codex_path_resolution.py
@@ -1,0 +1,71 @@
+"""Integration tests for codex agent PATH resolution."""
+
+from __future__ import annotations
+
+import asyncio
+import stat
+from pathlib import Path
+
+import pytest
+
+from clink.agents.codex import CodexAgent
+from clink.models import ResolvedCLIClient, ResolvedCLIRole
+
+
+class DummyProcess:
+    def __init__(self, *, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+
+    async def communicate(self, _input):
+        return self._stdout, self._stderr
+
+
+@pytest.fixture()
+def codex_agent():
+    prompt_path = Path("systemprompts/clink/default.txt").resolve()
+    role = ResolvedCLIRole(name="default", prompt_path=prompt_path, role_args=[])
+    client = ResolvedCLIClient(
+        name="codex",
+        executable=["codex"],
+        internal_args=["exec"],
+        config_args=["--json", "--dangerously-bypass-approvals-and-sandbox"],
+        env={},
+        timeout_seconds=30,
+        parser="codex_jsonl",
+        roles={"default": role},
+        output_to_file=None,
+        working_dir=None,
+    )
+    return CodexAgent(client), role
+
+
+@pytest.mark.asyncio
+async def test_codex_agent_resolves_nvm_installed_binary(monkeypatch, codex_agent, tmp_path):
+    agent, role = codex_agent
+    nvm_bin = tmp_path / ".nvm" / "versions" / "node" / "v22.0.0" / "bin"
+    nvm_bin.mkdir(parents=True)
+    codex_path = nvm_bin / "codex"
+    codex_path.write_text("#!/bin/sh\necho codex\n")
+    codex_path.chmod(codex_path.stat().st_mode | stat.S_IEXEC)
+
+    monkeypatch.setenv("NVM_DIR", str(tmp_path / ".nvm"))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        captured["args"] = args
+        captured["env"] = _kwargs.get("env")
+        return DummyProcess(stdout=b'{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}', returncode=0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    await agent.run(role=role, prompt="ping", files=[], images=[])
+
+    assert captured["args"][0] == str(codex_path)
+    env = captured["env"]
+    assert env is not None
+    assert str(nvm_bin) in env["PATH"].split(":")

--- a/tests/test_clink_gemini_agent.py
+++ b/tests/test_clink_gemini_agent.py
@@ -42,7 +42,7 @@ async def _run_agent_with_process(monkeypatch, agent, role, process):
     async def fake_create_subprocess_exec(*_args, **_kwargs):
         return process
 
-    def fake_which(executable_name):
+    def fake_which(executable_name, path=None):
         return f"/usr/bin/{executable_name}"
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)

--- a/tests/test_clink_path_resolution.py
+++ b/tests/test_clink_path_resolution.py
@@ -1,0 +1,50 @@
+"""Tests for clink CLI executable path resolution."""
+
+from __future__ import annotations
+
+import os
+import stat
+
+from clink.path_resolution import augment_path, resolve_cli_executable
+
+
+def test_resolve_cli_executable_uses_existing_path(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    codex_path = bin_dir / "codex"
+    codex_path.write_text("#!/bin/sh\necho codex\n")
+    codex_path.chmod(codex_path.stat().st_mode | stat.S_IEXEC)
+
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    assert resolve_cli_executable("codex") == str(codex_path)
+
+
+def test_resolve_cli_executable_finds_nvm_global_install(tmp_path, monkeypatch):
+    nvm_bin = tmp_path / ".nvm" / "versions" / "node" / "v22.0.0" / "bin"
+    nvm_bin.mkdir(parents=True)
+    codex_path = nvm_bin / "codex"
+    codex_path.write_text("#!/bin/sh\necho codex\n")
+    codex_path.chmod(codex_path.stat().st_mode | stat.S_IEXEC)
+
+    monkeypatch.setenv("NVM_DIR", str(tmp_path / ".nvm"))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    assert resolve_cli_executable("codex") == str(codex_path)
+
+
+def test_resolve_cli_executable_returns_none_when_missing(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    monkeypatch.setenv("HOME", "/nonexistent-home")
+
+    assert resolve_cli_executable("definitely-missing-cli") is None
+
+
+def test_augment_path_prepends_candidate_dirs(tmp_path, monkeypatch):
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    augmented = augment_path("/usr/bin")
+    assert str(local_bin) in augmented.split(os.pathsep)
+    assert augmented.endswith("/usr/bin") or "/usr/bin" in augmented.split(os.pathsep)


### PR DESCRIPTION
## Summary

Fix `clink` failing with `codex: command not found` when Codex CLI is installed globally via nvm + npm and PAL MCP is launched through `uvx`, which does not inherit nvm-injected PATH entries.

## Motivation

Fixes #442. The MCP subprocess inherits a minimal PATH from `uvx`, so `shutil.which('codex')` cannot find binaries installed under `$NVM_DIR/versions/node/*/bin`.

## Changes

- Add `clink/path_resolution.py` with `resolve_cli_executable()` and `augment_path()` to search common user-local install directories (nvm node bins, `~/.local/bin`, `~/.npm-global/bin`, etc.)
- Update `clink/agents/base.py` to resolve CLI executables via the augmented lookup and pass an augmented PATH to subprocesses
- Add unit and integration tests for nvm-style layouts
- Update existing agent test `fake_which` stubs to accept `path=` (required by `shutil.which`)

## Tests

```bash
pytest tests/test_clink_path_resolution.py tests/test_clink_codex_path_resolution.py tests/test_clink_codex_agent.py tests/test_clink_claude_agent.py tests/test_clink_gemini_agent.py -q
# 12 passed
```

## Notes

- Resolution still prefers the inherited PATH; augmented directories are only used as fallback.
- Mirrors the native CLI discovery pattern already used in `run-server.sh` for Claude/Codex integration.
- Does not cover fnm/volta/asdf layouts; can be extended if needed.