### PR TITLE
fix(chat): detect CONTINUATION conversation history headers

### DIFF
--- a/simulator_tests/test_chat_simple_validation.py
+++ b/simulator_tests/test_chat_simple_validation.py
@@ -13,7 +13,6 @@ Comprehensive test for the new ChatSimple tool implementation that validates:
 - Conversation context preservation across turns
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_conversation_chain_validation.py
+++ b/simulator_tests/test_conversation_chain_validation.py
@@ -21,7 +21,6 @@ This validates the conversation threading system's ability to:
 - Properly traverse parent relationships for history reconstruction
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_cross_tool_comprehensive.py
+++ b/simulator_tests/test_cross_tool_comprehensive.py
@@ -12,7 +12,6 @@ Validates:
 5. Proper tool chaining with context
 """
 
-
 from .conversation_base_test import ConversationBaseTest
 
 

--- a/simulator_tests/test_ollama_custom_url.py
+++ b/simulator_tests/test_ollama_custom_url.py
@@ -9,7 +9,6 @@ Tests custom API endpoint functionality with Ollama-style local models, includin
 - Model alias resolution for local models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_fallback.py
+++ b/simulator_tests/test_openrouter_fallback.py
@@ -8,7 +8,6 @@ Tests that verify the system correctly falls back to OpenRouter when:
 - Auto mode correctly selects OpenRouter models
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_openrouter_models.py
+++ b/simulator_tests/test_openrouter_models.py
@@ -9,7 +9,6 @@ Tests that verify OpenRouter functionality including:
 - Error handling when models are not available
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/simulator_tests/test_xai_models.py
+++ b/simulator_tests/test_xai_models.py
@@ -9,7 +9,6 @@ Tests that verify X.AI GROK functionality including:
 - API integration and response validation
 """
 
-
 from .base_test import BaseSimulatorTest
 
 

--- a/tests/test_conversation_continuation_integration.py
+++ b/tests/test_conversation_continuation_integration.py
@@ -1,8 +1,40 @@
 """Integration test for conversation continuation persistence."""
 
 from tools.chat import ChatRequest, ChatTool
-from utils.conversation_memory import get_thread
+from utils.conversation_memory import get_thread, has_embedded_conversation_history
 from utils.storage_backend import get_storage_backend
+
+
+def test_has_embedded_conversation_history_detects_continuation_header():
+    prompt = """=== CONVERSATION HISTORY (CONTINUATION) ===
+Thread: 12345678-1234-1234-1234-123456789012
+Previous conversation turns:
+
+--- Turn 1 (Agent) ---
+hello
+
+=== END CONVERSATION HISTORY ===
+
+=== NEW USER INPUT ===
+continue
+"""
+    assert has_embedded_conversation_history(prompt) is True
+
+
+def test_has_embedded_conversation_history_detects_legacy_header():
+    prompt = """=== CONVERSATION HISTORY ===
+Thread: 12345678-1234-1234-1234-123456789012
+
+=== END CONVERSATION HISTORY ===
+
+=== NEW USER INPUT ===
+continue
+"""
+    assert has_embedded_conversation_history(prompt) is True
+
+
+def test_has_embedded_conversation_history_rejects_plain_prompt():
+    assert has_embedded_conversation_history("continue the discussion") is False
 
 
 def test_first_response_persisted_in_conversation_history(tmp_path):

--- a/tests/test_directory_expansion_tracking.py
+++ b/tests/test_directory_expansion_tracking.py
@@ -37,8 +37,7 @@ class TestDirectoryExpansionTracking:
         files = []
         for i in range(5):
             swift_file = temp_path / f"File{i}.swift"
-            swift_file.write_text(
-                f"""
+            swift_file.write_text(f"""
 import Foundation
 
 class TestClass{i} {{
@@ -46,18 +45,15 @@ class TestClass{i} {{
         return "test{i}"
     }}
 }}
-"""
-            )
+""")
             files.append(str(swift_file))
 
         # Create a Python file as well
         python_file = temp_path / "helper.py"
-        python_file.write_text(
-            """
+        python_file.write_text("""
 def helper_function():
     return "helper"
-"""
-        )
+""")
         files.append(str(python_file))
 
         try:

--- a/tests/test_docker_implementation.py
+++ b/tests/test_docker_implementation.py
@@ -310,13 +310,11 @@ def temp_project_dir():
 
         # Create base files
         (temp_path / "server.py").write_text("# Mock server.py")
-        (temp_path / "Dockerfile").write_text(
-            """
+        (temp_path / "Dockerfile").write_text("""
 FROM python:3.11-slim
 COPY server.py /app/
 CMD ["python", "/app/server.py"]
-"""
-        )
+""")
 
         yield temp_path
 

--- a/tests/test_large_prompt_handling.py
+++ b/tests/test_large_prompt_handling.py
@@ -620,14 +620,15 @@ class TestLargePromptHandling:
 
         # Mock huge conversation history (simulates many turns of conversation)
         # Calculate repetitions needed to exceed MCP_PROMPT_SIZE_LIMIT
-        base_text = "=== CONVERSATION HISTORY ===\n"
+        base_text = "=== CONVERSATION HISTORY (CONTINUATION) ===\n"
         repeat_text = "Previous message content\n"
+        end_text = "=== END CONVERSATION HISTORY ===\n"
         # Add buffer to ensure we exceed the limit
         target_size = MCP_PROMPT_SIZE_LIMIT + 1000
-        available_space = target_size - len(base_text)
+        available_space = target_size - len(base_text) - len(end_text)
         repetitions_needed = (available_space // len(repeat_text)) + 1
 
-        huge_conversation_history = base_text + (repeat_text * repetitions_needed)
+        huge_conversation_history = base_text + (repeat_text * repetitions_needed) + end_text
 
         # Ensure the history exceeds MCP limits
         assert len(huge_conversation_history) > MCP_PROMPT_SIZE_LIMIT
@@ -677,7 +678,7 @@ class TestLargePromptHandling:
                     # Simulate the case where conversation history is already embedded in prompt
                     # by server.py before calling the tool
                     field_value = arguments.get("prompt", "")
-                    if "=== CONVERSATION HISTORY ===" in field_value:
+                    if "=== CONVERSATION HISTORY" in field_value and "=== END CONVERSATION HISTORY ===" in field_value:
                         # Set the flag that history is embedded
                         self._has_embedded_history = True
 

--- a/tests/test_prompt_regression.py
+++ b/tests/test_prompt_regression.py
@@ -86,16 +86,14 @@ class TestPromptIntegration:
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def hello_world():
     \"\"\"A simple hello world function.\"\"\"
     return "Hello, World!"
 
 if __name__ == "__main__":
     print(hello_world())
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -155,8 +153,7 @@ if __name__ == "__main__":
 
         # Create a temporary Python file for testing
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 def process_user_input(user_input):
     # Potentially unsafe code for demonstration
     query = f"SELECT * FROM users WHERE name = '{user_input}'"
@@ -166,8 +163,7 @@ def main():
     user_name = input("Enter name: ")
     result = process_user_input(user_name)
     print(result)
-"""
-            )
+""")
             temp_file = f.name
 
         try:
@@ -241,8 +237,7 @@ def main():
 
         # Create a temporary Python file demonstrating MVC pattern
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(
-                """
+            f.write("""
 # Model
 class User:
     def __init__(self, name, email):
@@ -262,8 +257,7 @@ class UserController:
 
     def get_user_display(self):
         return self.view.display_user(self.model)
-"""
-            )
+""")
             temp_file = f.name
 
         try:

--- a/tools/simple/base.py
+++ b/tools/simple/base.py
@@ -332,7 +332,14 @@ class SimpleTool(BaseTool):
             if continuation_id:
                 # Check if conversation history is already embedded
                 field_value = self.get_request_prompt(request)
-                if "=== CONVERSATION HISTORY ===" in field_value:
+                from utils.conversation_memory import (
+                    add_turn,
+                    build_conversation_history,
+                    get_thread,
+                    has_embedded_conversation_history,
+                )
+
+                if has_embedded_conversation_history(field_value):
                     # Use pre-embedded history
                     prompt = field_value
                     logger.debug(f"{self.get_name()}: Using pre-embedded conversation history")
@@ -341,8 +348,6 @@ class SimpleTool(BaseTool):
                     logger.debug(f"{self.get_name()}: No embedded history found, reconstructing conversation")
 
                     # Get thread context
-                    from utils.conversation_memory import add_turn, build_conversation_history, get_thread
-
                     thread_context = get_thread(continuation_id)
 
                     if thread_context:

--- a/utils/conversation_memory.py
+++ b/utils/conversation_memory.py
@@ -635,6 +635,14 @@ def _plan_file_inclusion_by_size(all_files: list[str], max_file_tokens: int) -> 
     return files_to_include, files_to_skip, total_tokens
 
 
+def has_embedded_conversation_history(prompt: str) -> bool:
+    """Return True when a prompt already contains server-built conversation history."""
+    return (
+        "=== CONVERSATION HISTORY" in prompt
+        and "=== END CONVERSATION HISTORY ===" in prompt
+    )
+
+
 def build_conversation_history(context: ThreadContext, model_context=None, read_files_func=None) -> tuple[str, int]:
     """
     Build formatted conversation history for tool prompts with embedded file contents.

--- a/utils/conversation_memory.py
+++ b/utils/conversation_memory.py
@@ -637,10 +637,7 @@ def _plan_file_inclusion_by_size(all_files: list[str], max_file_tokens: int) -> 
 
 def has_embedded_conversation_history(prompt: str) -> bool:
     """Return True when a prompt already contains server-built conversation history."""
-    return (
-        "=== CONVERSATION HISTORY" in prompt
-        and "=== END CONVERSATION HISTORY ===" in prompt
-    )
+    return "=== CONVERSATION HISTORY" in prompt and "=== END CONVERSATION HISTORY ===" in prompt
 
 
 def build_conversation_history(context: ThreadContext, model_context=None, read_files_func=None) -> tuple[str, int]:


### PR DESCRIPTION
## Summary

Fix duplicate conversation history reconstruction when the server injects a `(CONTINUATION)` header during chat continuations.

## Motivation

`server.py` embeds history using `build_conversation_history()`, which emits:

```
=== CONVERSATION HISTORY (CONTINUATION) ===
```

`SimpleTool` only checked for the exact legacy sentinel `=== CONVERSATION HISTORY ===`, so continuation prompts with the server header were treated as missing history. The tool then rebuilt the thread again, duplicating context and inflating prompt size.

Fixes #459

## Changes

- Add `has_embedded_conversation_history()` in `utils/conversation_memory.py`
- Use the helper in `tools/simple/base.py` when deciding whether to reuse pre-embedded history
- Add regression tests for continuation and legacy header formats

## Tests

```bash
pytest tests/test_conversation_continuation_integration.py -q
```

Result: 4 passed

## Notes

- Detection requires both the start prefix (`=== CONVERSATION HISTORY`) and end marker (`=== END CONVERSATION HISTORY ===`) to avoid false positives.
- No runtime behavior change for in-process continuation paths that legitimately need reconstruction.