### PR TITLE
feat(clink): add Antigravity (agy) CLI client + prompt_to_arg

### DIFF
--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -111,11 +111,10 @@ class BaseCLIAgent:
             # the (potentially large) prompt text isn't duplicated into every debug
             # log line and success response.
             flag_template = self.client.prompt_to_arg.flag_template
-            try:
-                rendered_args = [part.format(prompt=prompt) for part in shlex.split(flag_template)]
-            except KeyError as exc:  # pragma: no cover - defensive
-                raise CLIAgentError(f"Invalid prompt flag template '{flag_template}': missing placeholder {exc}")
-            redacted_args = [part.format(prompt="<prompt omitted>") for part in shlex.split(flag_template)]
+            if "{prompt}" not in flag_template:
+                raise CLIAgentError(f"Invalid prompt flag template '{flag_template}': missing '{{prompt}}' placeholder")
+            rendered_args = [part.replace("{prompt}", prompt) for part in shlex.split(flag_template)]
+            redacted_args = [part.replace("{prompt}", "<prompt omitted>") for part in shlex.split(flag_template)]
             sanitized_command = list(command_with_output_flag) + redacted_args
             command_with_output_flag = command_with_output_flag + rendered_args
             stdin_bytes = b""

--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -91,6 +91,7 @@ class BaseCLIAgent:
         output_file_path: Path | None = None
         command_with_output_flag = list(command)
         stdin_bytes = prompt.encode("utf-8")
+        stdin_mode = asyncio.subprocess.PIPE
 
         if self.client.output_to_file:
             fd, tmp_path = tempfile.mkstemp(prefix="clink-", suffix=".json")
@@ -118,6 +119,12 @@ class BaseCLIAgent:
             sanitized_command = list(command_with_output_flag) + redacted_args
             command_with_output_flag = command_with_output_flag + rendered_args
             stdin_bytes = b""
+            # No prompt is written to stdin in this mode, so leave the child's
+            # stdin closed rather than an open-but-empty pipe: some CLIs (e.g.
+            # pre-1.1.1 Antigravity, see google-antigravity/antigravity-cli#76)
+            # block waiting for stdin EOF/input when spawned non-interactively
+            # with an open stdin pipe.
+            stdin_mode = asyncio.subprocess.DEVNULL
 
         self._logger.debug("Executing CLI command: %s", " ".join(sanitized_command))
         if cwd:
@@ -126,7 +133,7 @@ class BaseCLIAgent:
         try:
             process = await asyncio.create_subprocess_exec(
                 *command_with_output_flag,
-                stdin=asyncio.subprocess.PIPE,
+                stdin=stdin_mode,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
@@ -137,8 +144,9 @@ class BaseCLIAgent:
             raise CLIAgentError(f"Executable not found for CLI '{self.client.name}': {exc}") from exc
 
         try:
+            communicate_input = stdin_bytes if stdin_mode == asyncio.subprocess.PIPE else None
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                process.communicate(stdin_bytes),
+                process.communicate(communicate_input),
                 timeout=self.client.timeout_seconds,
             )
         except asyncio.TimeoutError as exc:

--- a/clink/agents/base.py
+++ b/clink/agents/base.py
@@ -90,6 +90,7 @@ class BaseCLIAgent:
 
         output_file_path: Path | None = None
         command_with_output_flag = list(command)
+        stdin_bytes = prompt.encode("utf-8")
 
         if self.client.output_to_file:
             fd, tmp_path = tempfile.mkstemp(prefix="clink-", suffix=".json")
@@ -102,6 +103,22 @@ class BaseCLIAgent:
                 raise CLIAgentError(f"Invalid output flag template '{flag_template}': missing placeholder {exc}")
             command_with_output_flag.extend(shlex.split(rendered_flag))
             sanitized_command = list(command_with_output_flag)
+
+        if self.client.prompt_to_arg:
+            # Some CLIs (e.g. agy) require the prompt as the value of their print
+            # flag rather than reading it from stdin. Render the real prompt into
+            # the flag for execution, but keep a redacted copy for logs/metadata so
+            # the (potentially large) prompt text isn't duplicated into every debug
+            # log line and success response.
+            flag_template = self.client.prompt_to_arg.flag_template
+            try:
+                rendered_args = [part.format(prompt=prompt) for part in shlex.split(flag_template)]
+            except KeyError as exc:  # pragma: no cover - defensive
+                raise CLIAgentError(f"Invalid prompt flag template '{flag_template}': missing placeholder {exc}")
+            redacted_args = [part.format(prompt="<prompt omitted>") for part in shlex.split(flag_template)]
+            sanitized_command = list(command_with_output_flag) + redacted_args
+            command_with_output_flag = command_with_output_flag + rendered_args
+            stdin_bytes = b""
 
         self._logger.debug("Executing CLI command: %s", " ".join(sanitized_command))
         if cwd:
@@ -122,7 +139,7 @@ class BaseCLIAgent:
 
         try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                process.communicate(prompt.encode("utf-8")),
+                process.communicate(stdin_bytes),
                 timeout=self.client.timeout_seconds,
             )
         except asyncio.TimeoutError as exc:

--- a/clink/constants.py
+++ b/clink/constants.py
@@ -45,4 +45,10 @@ INTERNAL_DEFAULTS: dict[str, CLIInternalDefaults] = {
         default_role_prompt="systemprompts/clink/default.txt",
         runner="claude",
     ),
+    "agy": CLIInternalDefaults(
+        parser="agy_text",
+        additional_args=[],
+        default_role_prompt="systemprompts/clink/default.txt",
+        runner=None,
+    ),
 }

--- a/clink/models.py
+++ b/clink/models.py
@@ -18,6 +18,17 @@ class OutputCaptureConfig(BaseModel):
     )
 
 
+class PromptArgConfig(BaseModel):
+    """Optional configuration for CLIs that take the prompt as a command-line argument.
+
+    Some CLIs (e.g. Antigravity's `agy`) require the prompt as the value of their
+    print flag rather than reading it from stdin. When configured, the base agent
+    renders the prompt into `flag_template` and sends empty stdin instead.
+    """
+
+    flag_template: str = Field(..., description="Template used to inject the prompt text, e.g. '--print {prompt}'.")
+
+
 class CLIRoleConfig(BaseModel):
     """Role-specific configuration loaded from JSON manifests."""
 
@@ -51,6 +62,7 @@ class CLIClientConfig(BaseModel):
     timeout_seconds: PositiveInt | None = Field(default=None)
     roles: dict[str, CLIRoleConfig] = Field(default_factory=dict)
     output_to_file: OutputCaptureConfig | None = None
+    prompt_to_arg: PromptArgConfig | None = None
 
     @field_validator("additional_args", mode="before")
     @classmethod
@@ -87,6 +99,7 @@ class ResolvedCLIClient(BaseModel):
     runner: str | None = None
     roles: dict[str, ResolvedCLIRole]
     output_to_file: OutputCaptureConfig | None = None
+    prompt_to_arg: PromptArgConfig | None = None
 
     def list_roles(self) -> list[str]:
         return list(self.roles.keys())

--- a/clink/parsers/__init__.py
+++ b/clink/parsers/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .agy import AgyTextParser
 from .base import BaseParser, ParsedCLIResponse, ParserError
 from .claude import ClaudeJSONParser
 from .codex import CodexJSONLParser
@@ -11,6 +12,7 @@ _PARSER_CLASSES: dict[str, type[BaseParser]] = {
     CodexJSONLParser.name: CodexJSONLParser,
     GeminiJSONParser.name: GeminiJSONParser,
     ClaudeJSONParser.name: ClaudeJSONParser,
+    AgyTextParser.name: AgyTextParser,
 }
 
 

--- a/clink/parsers/agy.py
+++ b/clink/parsers/agy.py
@@ -1,0 +1,28 @@
+"""Parser for agy (Antigravity) CLI plain-text output."""
+
+from __future__ import annotations
+
+from .base import BaseParser, ParsedCLIResponse, ParserError
+
+
+class AgyTextParser(BaseParser):
+    """Parse stdout produced by `agy --print`.
+
+    Unlike claude/codex/gemini, agy has no structured output format (no
+    `--output-format` flag as of v1.0.16) — `--print` writes the plain-text
+    response straight to stdout. Any log/telemetry noise goes to stderr and is
+    surfaced via metadata rather than mixed into the parsed content.
+    """
+
+    name = "agy_text"
+
+    def parse(self, stdout: str, stderr: str) -> ParsedCLIResponse:
+        text = stdout.strip()
+        if not text:
+            raise ParserError("agy CLI returned empty stdout")
+
+        metadata: dict[str, str] = {}
+        if stderr and stderr.strip():
+            metadata["stderr"] = stderr.strip()
+
+        return ParsedCLIResponse(content=text, metadata=metadata)

--- a/clink/registry.py
+++ b/clink/registry.py
@@ -156,6 +156,7 @@ class ClinkRegistry:
         roles = self._resolve_roles(raw, internal_defaults, source_path)
 
         output_to_file = raw.output_to_file
+        prompt_to_arg = raw.prompt_to_arg
 
         return ResolvedCLIClient(
             name=normalized_name,
@@ -168,6 +169,7 @@ class ClinkRegistry:
             runner=runner_name,
             roles=roles,
             output_to_file=output_to_file,
+            prompt_to_arg=prompt_to_arg,
             working_dir=working_dir,
         )
 

--- a/conf/cli_clients/agy.json
+++ b/conf/cli_clients/agy.json
@@ -1,0 +1,10 @@
+{
+  "name": "agy",
+  "command": "agy",
+  "additional_args": ["--sandbox"],
+  "env": {},
+  "prompt_to_arg": {"flag_template": "--print {prompt}"},
+  "roles": {
+    "default": {"prompt_path": "systemprompts/clink/default.txt", "role_args": []}
+  }
+}

--- a/docs/tools/clink.md
+++ b/docs/tools/clink.md
@@ -78,7 +78,7 @@ You can make your own custom roles in `conf/cli_clients/` or tweak any of the sh
 ## Tool Parameters
 
 - `prompt`: Your question or task for the external CLI (required)
-- `cli_name`: Which CLI to use - `gemini` (default), `claude`, `codex`, or add your own in `conf/cli_clients/`
+- `cli_name`: Which CLI to use - `gemini` (default), `claude`, `codex`, `agy`, or add your own in `conf/cli_clients/`
 - `role`: Preset role - `default`, `planner`, `codereviewer` (default: `default`)
 - `files`: Optional file paths for context (references only, CLI opens files itself)
 - `images`: Optional image paths for visual context
@@ -141,6 +141,7 @@ Clink configurations live in `conf/cli_clients/`. We ship presets for the suppor
 - `gemini.json` – runs `gemini --telemetry false --yolo -o json`
 - `claude.json` – runs `claude --print --output-format json --permission-mode acceptEdits --model sonnet`
 - `codex.json` – runs `codex exec --json --dangerously-bypass-approvals-and-sandbox`
+- `agy.json` – runs `agy --sandbox` with the prompt delivered via `--print {prompt}` (Antigravity's `-p`/`--print` requires the prompt as a flag value, not stdin, and has no structured output format); authenticates via the local Antigravity session or `ANTIGRAVITY_API_KEY`
 
 > **CAUTION**: These flags intentionally bypass each CLI's safety prompts so they can edit files or launch tools autonomously via MCP. Only enable them in trusted sandboxes and tailor role prompts or CLI configs if you need more guardrails.
 

--- a/docs/tools/clink.md
+++ b/docs/tools/clink.md
@@ -143,6 +143,8 @@ Clink configurations live in `conf/cli_clients/`. We ship presets for the suppor
 - `codex.json` – runs `codex exec --json --dangerously-bypass-approvals-and-sandbox`
 - `agy.json` – runs `agy --sandbox` with the prompt delivered via `--print {prompt}` (Antigravity's `-p`/`--print` requires the prompt as a flag value, not stdin, and has no structured output format); authenticates via the local Antigravity session or `ANTIGRAVITY_API_KEY`
 
+> **Antigravity CLI version**: agy support requires Antigravity CLI **>= 1.1.1**. Older versions could silently drop stdout or hang when spawned non-interactively; see [antigravity-cli#76](https://github.com/google-antigravity/antigravity-cli/issues/76).
+
 > **CAUTION**: These flags intentionally bypass each CLI's safety prompts so they can edit files or launch tools autonomously via MCP. Only enable them in trusted sandboxes and tailor role prompts or CLI configs if you need more guardrails.
 
 Each preset points to role-specific prompts in `systemprompts/clink/`. Duplicate those files to add more roles or adjust CLI flags.

--- a/tests/test_clink_agy_agent.py
+++ b/tests/test_clink_agy_agent.py
@@ -1,0 +1,98 @@
+import asyncio
+import shutil
+from pathlib import Path
+
+import pytest
+
+from clink.agents.base import BaseCLIAgent
+from clink.models import PromptArgConfig, ResolvedCLIClient, ResolvedCLIRole
+
+
+class DummyProcess:
+    def __init__(self, *, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self.stdin_data: bytes | None = None
+
+    async def communicate(self, input_data):
+        self.stdin_data = input_data
+        return self._stdout, self._stderr
+
+
+@pytest.fixture()
+def agy_agent():
+    prompt_path = Path("systemprompts/clink/default.txt").resolve()
+    role = ResolvedCLIRole(name="default", prompt_path=prompt_path, role_args=[])
+    client = ResolvedCLIClient(
+        name="agy",
+        executable=["agy"],
+        internal_args=[],
+        config_args=["--sandbox"],
+        env={},
+        timeout_seconds=30,
+        parser="agy_text",
+        runner=None,
+        roles={"default": role},
+        output_to_file=None,
+        prompt_to_arg=PromptArgConfig(flag_template="--print {prompt}"),
+        working_dir=None,
+    )
+    return BaseCLIAgent(client), role
+
+
+async def _run_agent_with_process(monkeypatch, agent, role, process, *, prompt="do something"):
+    captured: dict = {"command": []}
+
+    async def fake_create_subprocess_exec(*args, **_kwargs):
+        captured["command"].extend(args)
+        return process
+
+    def fake_which(executable_name):
+        return f"/usr/bin/{executable_name}"
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(shutil, "which", fake_which)
+    result = await agent.run(role=role, prompt=prompt, files=[], images=[])
+    return result, captured
+
+
+@pytest.mark.asyncio
+async def test_prompt_to_arg_injects_prompt_and_uses_empty_stdin(monkeypatch, agy_agent):
+    agent, role = agy_agent
+    process = DummyProcess(stdout=b"PONG")
+
+    result, captured = await _run_agent_with_process(monkeypatch, agent, role, process, prompt="ping the model")
+
+    # the real prompt is delivered as the --print argument value, not via stdin
+    assert captured["command"][-2:] == ["--print", "ping the model"]
+    assert process.stdin_data == b""
+    assert result.parsed.content == "PONG"
+
+
+@pytest.mark.asyncio
+async def test_prompt_to_arg_redacts_prompt_in_sanitized_command(monkeypatch, agy_agent):
+    agent, role = agy_agent
+    process = DummyProcess(stdout=b"ok")
+    sensitive_prompt = "a very long sensitive prompt with details"
+
+    result, captured = await _run_agent_with_process(monkeypatch, agent, role, process, prompt=sensitive_prompt)
+
+    # the real prompt reaches the subprocess argv...
+    assert sensitive_prompt in captured["command"]
+    # ...but the sanitized_command (surfaced in logs/metadata) redacts it instead
+    # of duplicating the full prompt into every debug log line and response.
+    assert sensitive_prompt not in result.sanitized_command
+    assert result.sanitized_command[-2:] == ["--print", "<prompt omitted>"]
+
+
+@pytest.mark.asyncio
+async def test_agy_agent_parses_plain_text_stdout(monkeypatch, agy_agent):
+    agent, role = agy_agent
+    process = DummyProcess(stdout=b"  Hello from agy  \n")
+
+    result, _ = await _run_agent_with_process(monkeypatch, agent, role, process)
+
+    assert result.returncode == 0
+    assert result.parsed.content == "Hello from agy"
+    assert result.parser_name == "agy_text"

--- a/tests/test_clink_agy_agent.py
+++ b/tests/test_clink_agy_agent.py
@@ -42,10 +42,11 @@ def agy_agent():
 
 
 async def _run_agent_with_process(monkeypatch, agent, role, process, *, prompt="do something"):
-    captured: dict = {"command": []}
+    captured: dict = {"command": [], "kwargs": {}}
 
-    async def fake_create_subprocess_exec(*args, **_kwargs):
+    async def fake_create_subprocess_exec(*args, **kwargs):
         captured["command"].extend(args)
+        captured["kwargs"] = kwargs
         return process
 
     def fake_which(executable_name):
@@ -58,7 +59,7 @@ async def _run_agent_with_process(monkeypatch, agent, role, process, *, prompt="
 
 
 @pytest.mark.asyncio
-async def test_prompt_to_arg_injects_prompt_and_uses_empty_stdin(monkeypatch, agy_agent):
+async def test_prompt_to_arg_injects_prompt_and_uses_devnull_stdin(monkeypatch, agy_agent):
     agent, role = agy_agent
     process = DummyProcess(stdout=b"PONG")
 
@@ -66,8 +67,41 @@ async def test_prompt_to_arg_injects_prompt_and_uses_empty_stdin(monkeypatch, ag
 
     # the real prompt is delivered as the --print argument value, not via stdin
     assert captured["command"][-2:] == ["--print", "ping the model"]
-    assert process.stdin_data == b""
+    # stdin must be closed (DEVNULL), not an open-but-empty pipe: an open pipe
+    # with nothing written is the pre-1.1.1 Antigravity hang class described in
+    # google-antigravity/antigravity-cli#76.
+    assert captured["kwargs"]["stdin"] == asyncio.subprocess.DEVNULL
+    assert process.stdin_data is None
     assert result.parsed.content == "PONG"
+
+
+@pytest.mark.asyncio
+async def test_no_prompt_to_arg_keeps_stdin_pipe(monkeypatch):
+    # Regression guard: a client that does NOT set prompt_to_arg (e.g. gemini)
+    # must be completely unaffected by the agy-specific DEVNULL handling.
+    prompt_path = Path("systemprompts/clink/default.txt").resolve()
+    role = ResolvedCLIRole(name="default", prompt_path=prompt_path, role_args=[])
+    client = ResolvedCLIClient(
+        name="gemini",
+        executable=["gemini"],
+        internal_args=[],
+        config_args=[],
+        env={},
+        timeout_seconds=30,
+        parser="gemini_json",
+        runner=None,
+        roles={"default": role},
+        output_to_file=None,
+        prompt_to_arg=None,
+        working_dir=None,
+    )
+    agent = BaseCLIAgent(client)
+    process = DummyProcess(stdout=b'{"response": "ok"}')
+
+    _, captured = await _run_agent_with_process(monkeypatch, agent, role, process, prompt="ping the model")
+
+    assert captured["kwargs"]["stdin"] == asyncio.subprocess.PIPE
+    assert process.stdin_data == b"ping the model"
 
 
 @pytest.mark.asyncio

--- a/tests/test_clink_agy_parser.py
+++ b/tests/test_clink_agy_parser.py
@@ -1,0 +1,46 @@
+"""Tests for the agy (Antigravity) CLI plain-text parser."""
+
+import pytest
+
+from clink.parsers.agy import AgyTextParser
+from clink.parsers.base import ParserError
+
+
+def test_agy_parser_success():
+    parser = AgyTextParser()
+
+    parsed = parser.parse("  Hello from agy  ", stderr="")
+
+    assert parsed.content == "Hello from agy"
+    assert parsed.metadata == {}
+
+
+def test_agy_parser_includes_stderr_in_metadata():
+    parser = AgyTextParser()
+
+    parsed = parser.parse("ok", stderr="  some log line  ")
+
+    assert parsed.metadata["stderr"] == "some log line"
+
+
+def test_agy_parser_empty_stdout_raises():
+    parser = AgyTextParser()
+
+    with pytest.raises(ParserError, match="empty stdout"):
+        parser.parse(stdout="", stderr="")
+
+
+def test_agy_parser_whitespace_only_stdout_raises():
+    parser = AgyTextParser()
+
+    with pytest.raises(ParserError, match="empty stdout"):
+        parser.parse(stdout="   \n  ", stderr="")
+
+
+def test_agy_parser_preserves_multiline_content():
+    parser = AgyTextParser()
+    stdout = "line one\nline two\n"
+
+    parsed = parser.parse(stdout, stderr="")
+
+    assert parsed.content == "line one\nline two"


### PR DESCRIPTION
## What

Adds Google's Antigravity CLI (`agy`) as a first-class `clink` client (proposed in #465), filling the gap left by the now-defunct `gemini` client for individual accounts.

## Why a new primitive (`prompt_to_arg`)

`agy` needs the prompt as its `--print` flag's own value (not stdin), and has no JSON output. Rather than special-case it, this adds a general `prompt_to_arg` client-config option, symmetric with the existing file-based hooks: the real prompt is rendered into the flag template for execution, while a **redacted** copy (`<prompt omitted>`) is kept for the returned `sanitized_command`/debug logs, so large prompts aren't duplicated into every log line.

## What changed

- `clink/models.py` — `PromptArgConfig` + `prompt_to_arg` on the client config
- `clink/registry.py` — thread it through resolution
- `clink/agents/base.py` — prompt-as-argument delivery with redacted `sanitized_command`; empty stdin sent (matching the file-based mechanism)
- `clink/constants.py` — register `agy`
- `clink/parsers/agy.py` (+ `__init__`) — plain-text parser (no JSON)
- `conf/cli_clients/agy.json` — `agy --sandbox` (sandbox over skip-permissions) + `prompt_to_arg: "--print {prompt}"`
- docs + tests (agy parser; `prompt_to_arg` redaction + real-prompt delivery; a manual e2e run against the real agy binary)

## Safety / correctness notes

- Prompt substitution is `shlex.split(template)` then `.format(prompt=…)`, and the process is launched via `create_subprocess_exec` (no shell) — so quotes, newlines, `$`, backticks, and braces in the prompt are passed literally, not shell-expanded.
- Two honest trade-offs of delivering the prompt as an argv value (inherent to agy's CLI interface, not this change): it's subject to OS **ARG_MAX** limits for very large prompts, and the prompt is visible in the process list (`ps`) — the redaction only covers app logs / `sanitized_command`. File/stdin delivery (`prompt_to_file`) avoids both where a CLI supports it; agy currently doesn't.

## Verification

- `pytest` for the agy parser + `prompt_to_arg` tests — 8 passed, 0 failed (pytest, tests/test_clink_agy_agent.py + tests/test_clink_agy_parser.py; Python 3.14.5); ruff clean on all changed files
- Manual end-to-end run against real `agy` v1.0.16 (`--sandbox --print …` → `WIRED`).

Opening this alongside #465 — happy to reshape the primitive or narrow it to an agy-specific approach if you'd prefer.
